### PR TITLE
Fix the issue of SAI next-hop member removal error when ports that accept routes that are eligible for default route swap are toggle multiple times

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -544,6 +544,12 @@ bool RouteOrch::invalidnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t
         }
 
         nexthop_id = nhopgroup->second.nhopgroup_members[nexthop].next_hop_id;
+
+        if (nhopgroup->second.is_default_route_nh_swap)
+        {
+            continue;
+        }
+
         status = sai_next_hop_group_api->remove_next_hop_group_member(nexthop_id);
 
         if (status != SAI_STATUS_SUCCESS)

--- a/tests/test_nhg.py
+++ b/tests/test_nhg.py
@@ -2039,6 +2039,26 @@ class TestNextHopGroup(TestNextHopGroupBase):
             assert rt_nhopsids == default_nhopsids
             assert rt_nhgmids != default_nhgmids
 
+            # bring links up one-by-one
+            # Bring link up in random order to verify sequence id is as per order
+            for i, val in enumerate([2,1,0]):
+                self.flap_intf(i, 'down')
+                time.sleep(1)
+
+                keys = self.asic_db.get_keys(self.ASIC_NHGM_STR)
+
+                assert len(keys) == 12
+
+            # bring links up one-by-one
+            # Bring link up in random order to verify sequence id is as per order
+            for i, val in enumerate([2,1,0]):
+                self.flap_intf(i, 'up')
+                time.sleep(1)
+
+                keys = self.asic_db.get_keys(self.ASIC_NHGM_STR)
+
+                assert len(keys) == 12
+
             # Remove route 2.2.2.0/24
             self.rt_ps._del(rtprefix)
             time.sleep(1)


### PR DESCRIPTION
What I did:
Fix the issue of SAI next-hop member removal error when ports that accept routes that are eligible for default route swap are toggle multiple times

Sequence of flow:
1. Port P1,P2 P3 accept routes  R that are eligible for default Route D nexthop port P4
2. R point to Nexthop Group (N) that contains  P1, P2 P3
3. P1, P2,P3 link goes down.  
4. R point to Nexthop Group (N) that now contains P4 and P1,P2,P3 are removed only from SAI
5. P1,P2,P3 link comes up. We do not add back P1,P2,P3 to N again as accept R to get deleted 
6. Now P1,P2,P3 link goes down again. Since we have already remove P1,P2,P3 we get SAI error as we try to remove P1,P2,P3 again. 

How I fix:
When scenario 6 happens check if Route is already pointing to Defafult Route Nexthop than we don;t need to delete that nexthop.

How I verify:
This scenario got uncovered running: https://github.com/sonic-net/sonic-mgmt/blob/master/tests/platform_tests/link_flap/test_cont_link_flap.py#L109.  

After fix issue is not seen