### PR TITLE
Enable FDB learning event after all ports removed from default 1Q bridge

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -512,13 +512,6 @@ int main(int argc, char **argv)
     attr.value.booldata = true;
     attrs.push_back(attr);
 
-    if (gMySwitchType != "dpu")
-    {
-        attr.id = SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY;
-        attr.value.ptr = (void *)on_fdb_event;
-        attrs.push_back(attr);
-    }
-
     attr.id = SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY;
     attr.value.ptr = (void *)on_port_state_change;
     attrs.push_back(attr);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -821,6 +821,21 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
         removeDefaultBridgePorts();
     }
 
+    // Enable fdb event notifications after all ports are removed from default 1Q bridge
+    // If fdb entry is learnt before this point, reference count will be incremented and
+    // the port will not be removed from the bridge
+    if (gMySwitchType != "dpu")
+    {
+        sai_attribute_t attr;
+        attr.id = SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY;
+        attr.value.ptr = (void *)on_fdb_event;
+        if (sai_switch_api->set_switch_attribute(gSwitchId, &attr) != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to set SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY attribute");
+            throw runtime_error("PortsOrch initialization failure (failed to set fdb event notify)");
+        }
+    }
+
     /* Add port oper status notification support */
     m_notificationsDb = make_shared<DBConnector>("ASIC_DB", 0);
     m_portStatusNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Cherry-picked from PR https://github.com/sonic-net/sonic-swss/pull/3630
This PR is to fix an orchagent crash issue. Error logs are as below.
```
2025 May  1 05:51:07.128331 str4-7060x6-64pe-7 ERR swss#orchagent: :- meta_generic_validation_remove: object 0x3a0000000000d7 reference count is 1, can't remove
2025 May  1 05:51:07.128331 str4-7060x6-64pe-7 ERR swss#orchagent: :- removeDefaultBridgePorts: Failed to remove bridge port, rv:-17
2025 May  1 05:51:07.128566 str4-7060x6-64pe-7 INFO swss#supervisord: orchagent terminate called after throwing an instance of 'std::runtime_error'
2025 May  1 05:51:07.128566 str4-7060x6-64pe-7 INFO swss#supervisord: orchagent   what():  PortsOrch initialization failure
2025 May  1 05:51:07.815330 str4-7060x6-64pe-7 INFO swss#supervisord 2025-05-01 05:51:07,814 WARN exited: orchagent (terminated by SIGABRT (core dumped); not expected)
```
It's because FDB is learnt on the default bridge, which increased reference count for bridge port and caused port removal failure.

The issue is addressed by **not** setting  `SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY` when creating switch, and enable it after all ports being removed from default bridge.

**Why I did it**
This PR is to fix an orchagent crash issue.

**How I verified it**
1. The change is verified on multiple platforms. FDB learning can be done normally after this change.

**Broadcom**
```
admin@str4-7060x6-64pe-fan-4:~$ fdbshow 
  No.    Vlan  MacAddress         Port         Type
-----  ------  -----------------  -----------  -------
    1    1234  B6:2C:7E:FC:80:00  Ethernet496  Dynamic
    2    1234  D6:5E:2C:C0:B8:0B  Ethernet496  Dynamic
    3    1235  CE:8F:2A:A1:00:01  Ethernet496  Dynamic
```
**Mellanox**
```
admin@str-msn2700-01:~$ fdbshow 
  No.    Vlan  MacAddress         Port       Type
-----  ------  -----------------  ---------  -------
    1    1000  7C:FE:90:5E:60:01  Ethernet4  Dynamic
Total number of entries 1
```

**Cisco**
```
admin@str3-8101-03:~$ fdbshow 
  No.    Vlan  MacAddress         Port         Type
-----  ------  -----------------  -----------  -------
    1    1000  9C:09:8B:B6:E6:00  Ethernet240  Dynamic
Total number of entries 1
```

2. The existing VS test `test_fdb.py` can cover the change.

**Details if related**
