### PR TITLE
Fix log level and treat skip nbrs and mux nbrs

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -899,7 +899,7 @@ bool MuxNbrHandler::disable(sai_object_id_t tnh)
             SWSS_LOG_ERROR("Removing existing NH failed for %s", nh_key.ip_address.to_string().c_str());
             return false;
         }
-        SWSS_LOG_ERROR("Removing existing NH for %s, nh_removed: %u", nh_key.ip_address.to_string().c_str(), nh_removed);
+        SWSS_LOG_INFO("Removing existing NH for %s, nh_removed: %u", nh_key.ip_address.to_string().c_str(), nh_removed);
 
         /* Decrement ref count for ECMP NH members */
         gNeighOrch->decreaseNextHopRefCount(nh_key, nh_removed);
@@ -1445,6 +1445,12 @@ MuxCable* MuxOrch::findMuxCableInSubnet(IpAddress ip)
 
 bool MuxOrch::isMuxPortNeighbor(const IpAddress& nbr, const MacAddress& mac, string& alias)
 {
+    // skip neighbors are treated as MUX port neighbor
+    if (isSkipNeighbor(nbr))
+    {
+        return true;
+    }
+
     if (mux_cable_tb_.empty())
     {
         // Check cached neighbors during warm boot

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1351,8 +1351,6 @@ class TestMuxTunnelBase():
         """
         Checks the status of neighbor entries in APPL and ASIC DB
         """
-        #if expect_route and expect_neigh:
-        #    pytest.fail('expect_routes and expect_neigh cannot both be True')
         standby_state=False
         if expect_route and expect_neigh==False:
             standby_state=True


### PR DESCRIPTION
Fixed a log level in PR https://github.com/Azure/sonic-swss.msft/pull/110
Treat skip neighbors like mux neighbors so that these neighbors are installed with no-host-route flag as well.