### PR TITLE
[orchagent]: HFTOrch init (#3759)

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -117,7 +117,12 @@ orchagent_SOURCES = \
             dash/dashaclgroupmgr.cpp \
             dash/dashtagmgr.cpp \
             dash/pbutils.cpp \
-            twamporch.cpp
+            twamporch.cpp \
+            high_frequency_telemetry/hftelorch.cpp \
+            high_frequency_telemetry/hftelprofile.cpp \
+            high_frequency_telemetry/counternameupdater.cpp \
+            high_frequency_telemetry/hftelutils.cpp \
+            high_frequency_telemetry/hftelgroup.cpp
 
 orchagent_SOURCES += flex_counter/flex_counter_manager.cpp flex_counter/flex_counter_stat_manager.cpp flex_counter/flow_counter_handler.cpp flex_counter/flowcounterrouteorch.cpp
 orchagent_SOURCES += debug_counter/debug_counter.cpp debug_counter/drop_counter.cpp

--- a/orchagent/high_frequency_telemetry/counternameupdater.cpp
+++ b/orchagent/high_frequency_telemetry/counternameupdater.cpp
@@ -1,0 +1,55 @@
+#include "counternameupdater.h"
+#include "hftelorch.h"
+
+#include <swss/logger.h>
+#include <sai_serialize.h>
+
+extern HFTelOrch *gHFTOrch;
+
+CounterNameMapUpdater::CounterNameMapUpdater(const std::string &db_name, const std::string &table_name)
+    : m_db_name(db_name),
+      m_table_name(table_name),
+      m_connector(m_db_name, 0),
+      m_counters_table(&m_connector, m_table_name)
+{
+    SWSS_LOG_ENTER();
+}
+
+void CounterNameMapUpdater::setCounterNameMap(const std::string &counter_name, sai_object_id_t oid)
+{
+    SWSS_LOG_ENTER();
+
+    if (gHFTOrch)
+    {
+        Message msg{
+            .m_table_name = m_table_name.c_str(),
+            .m_operation = OPERATION::SET,
+            .m_set{
+                .m_counter_name = counter_name.c_str(),
+                .m_oid = oid,
+            },
+        };
+        gHFTOrch->locallyNotify(msg);
+    }
+
+    m_counters_table.hset("", counter_name, sai_serialize_object_id(oid));
+}
+
+void CounterNameMapUpdater::delCounterNameMap(const std::string &counter_name)
+{
+    SWSS_LOG_ENTER();
+
+    if (gHFTOrch)
+    {
+        Message msg{
+            .m_table_name = m_table_name.c_str(),
+            .m_operation = OPERATION::DEL,
+            .m_del{
+                .m_counter_name = counter_name.c_str(),
+            },
+        };
+        gHFTOrch->locallyNotify(msg);
+    }
+
+    m_counters_table.hdel("", counter_name);
+}

--- a/orchagent/high_frequency_telemetry/counternameupdater.h
+++ b/orchagent/high_frequency_telemetry/counternameupdater.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <swss/rediscommand.h>
+#include <swss/table.h>
+#include <saitypes.h>
+
+class CounterNameMapUpdater
+{
+public:
+
+    enum OPERATION
+    {
+        SET,
+        DEL,
+    };
+
+    struct SetPayload
+    {
+        const char* m_counter_name;
+        sai_object_id_t m_oid;
+    };
+
+    struct DelPayload
+    {
+        const char* m_counter_name;
+    };
+
+    struct Message
+    {
+        const char* m_table_name;
+        OPERATION m_operation;
+        union
+        {
+            SetPayload m_set;
+            DelPayload m_del;
+        };
+    };
+
+    CounterNameMapUpdater(const std::string &db_name, const std::string &table_name);
+    ~CounterNameMapUpdater() = default;
+
+    void setCounterNameMap(const std::string &counter_name, sai_object_id_t oid);
+    void delCounterNameMap(const std::string &counter_name);
+
+private:
+    std::string m_db_name;
+    std::string m_table_name;
+    swss::DBConnector m_connector;
+    swss::Table m_counters_table;
+};

--- a/orchagent/high_frequency_telemetry/hftelgroup.cpp
+++ b/orchagent/high_frequency_telemetry/hftelgroup.cpp
@@ -1,0 +1,56 @@
+#include "hftelgroup.h"
+#include "hftelutils.h"
+
+#include <swss/logger.h>
+
+using namespace std;
+
+HFTelGroup::HFTelGroup(const string &group_name) : m_group_name(group_name)
+{
+    SWSS_LOG_ENTER();
+}
+
+void HFTelGroup::updateObjects(const set<string> &object_names)
+{
+    SWSS_LOG_ENTER();
+
+    m_objects.clear();
+    sai_uint16_t lable = 1;
+    for (auto &name : object_names)
+    {
+        m_objects[name] = lable++;
+    }
+}
+
+void HFTelGroup::updateStatsIDs(const std::set<sai_stat_id_t> &stats_ids)
+{
+    SWSS_LOG_ENTER();
+
+    m_stats_ids = move(stats_ids);
+}
+
+bool HFTelGroup::isSameObjects(const std::set<std::string> &object_names) const
+{
+    SWSS_LOG_ENTER();
+
+    if (m_objects.size() == object_names.size())
+    {
+        for (const auto &name : object_names)
+        {
+            if (m_objects.find(name) == m_objects.end())
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    return false;
+}
+
+bool HFTelGroup::isObjectInGroup(const string &object_name) const
+{
+    SWSS_LOG_ENTER();
+
+    return m_objects.find(object_name) != m_objects.end();
+}

--- a/orchagent/high_frequency_telemetry/hftelgroup.h
+++ b/orchagent/high_frequency_telemetry/hftelgroup.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <vector>
+#include <unordered_map>
+#include <set>
+#include <string>
+
+#include <saitypes.h>
+
+
+class HFTelGroup
+{
+public:
+    HFTelGroup() = delete;
+    HFTelGroup(const std::string& group_name);
+    ~HFTelGroup() = default;
+    void updateObjects(const std::set<std::string> &object_names);
+    void updateStatsIDs(const std::set<sai_stat_id_t> &stats_ids);
+    bool isSameObjects(const std::set<std::string> &object_names) const;
+    bool isObjectInGroup(const std::string &object_name) const;
+    const std::unordered_map<std::string, sai_uint16_t>& getObjects() const { return m_objects; }
+    const std::set<sai_stat_id_t>& getStatsIDs() const { return m_stats_ids; }
+    std::pair<std::vector<std::string>, std::vector<std::string>> getObjectNamesAndLabels() const
+    {
+        std::vector<std::string> names;
+        std::vector<std::string> labels;
+        names.reserve(m_objects.size());
+        labels.reserve(m_objects.size());
+        for (const auto& obj : m_objects)
+        {
+            names.push_back(obj.first);
+            labels.push_back(std::to_string(obj.second));
+        }
+        return {names, labels};
+    }
+
+private:
+    std::string m_group_name;
+    // Object names and label IDs
+    std::unordered_map<std::string, sai_uint16_t> m_objects;
+    std::set<sai_stat_id_t> m_stats_ids;
+};

--- a/orchagent/high_frequency_telemetry/hftelorch.cpp
+++ b/orchagent/high_frequency_telemetry/hftelorch.cpp
@@ -1,0 +1,728 @@
+#include "hftelorch.h"
+#include "hftelutils.h"
+
+#include "notifications.h"
+
+#include <swss/schema.h>
+#include <swss/redisutility.h>
+#include <swss/stringutility.h>
+#include <swss/tokenize.h>
+#include <saihelper.h>
+#include <notifier.h>
+
+#include <yaml-cpp/yaml.h>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptor/transformed.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <algorithm>
+
+using namespace std;
+using namespace swss;
+
+#define CONSTANTS_FILE "/et/sonic/constants.yml"
+
+const unordered_map<string, sai_object_type_t> HFTelOrch::SUPPORT_COUNTER_TABLES = {
+    {COUNTERS_PORT_NAME_MAP, SAI_OBJECT_TYPE_PORT},
+    {COUNTERS_BUFFER_POOL_NAME_MAP, SAI_OBJECT_TYPE_BUFFER_POOL},
+    {COUNTERS_QUEUE_NAME_MAP, SAI_OBJECT_TYPE_QUEUE},
+    {COUNTERS_PG_NAME_MAP, SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP},
+};
+
+extern sai_object_id_t gSwitchId;
+extern sai_switch_api_t *sai_switch_api;
+extern sai_hostif_api_t *sai_hostif_api;
+extern sai_tam_api_t *sai_tam_api;
+
+namespace swss
+{
+
+    template <>
+    inline void lexical_convert(const string &buffer, sai_tam_tel_type_state_t &stage)
+    {
+        SWSS_LOG_ENTER();
+
+        if (buffer == "enabled")
+        {
+            stage = SAI_TAM_TEL_TYPE_STATE_START_STREAM;
+        }
+        else if (buffer == "disabled")
+        {
+            stage = SAI_TAM_TEL_TYPE_STATE_STOP_STREAM;
+        }
+        else
+        {
+            SWSS_LOG_THROW("Invalid stream state %s for high frequency telemetry", buffer.c_str());
+        }
+    }
+
+}
+
+HFTelOrch::HFTelOrch(
+    DBConnector *cfg_db,
+    DBConnector *state_db,
+    const vector<string> &tables)
+    : Orch(cfg_db, tables),
+      m_state_telemetry_session(state_db, STATE_HIGH_FREQUENCY_TELEMETRY_SESSION_TABLE_NAME),
+      m_asic_db("ASIC_DB", 0),
+      m_sai_hostif_obj(SAI_NULL_OBJECT_ID),
+      m_sai_hostif_trap_group_obj(SAI_NULL_OBJECT_ID),
+      m_sai_hostif_user_defined_trap_obj(SAI_NULL_OBJECT_ID),
+      m_sai_hostif_table_entry_obj(SAI_NULL_OBJECT_ID),
+      m_sai_tam_transport_obj(SAI_NULL_OBJECT_ID),
+      m_sai_tam_collector_obj(SAI_NULL_OBJECT_ID)
+{
+    SWSS_LOG_ENTER();
+
+    createNetlinkChannel("sonic_stel", "ipfix");
+    createTAM();
+
+    m_asic_notification_consumer = make_shared<NotificationConsumer>(&m_asic_db, "NOTIFICATIONS");
+    auto notifier = new Notifier(m_asic_notification_consumer.get(), this, "TAM_TEL_TYPE_STATE");
+    sai_attribute_t attr;
+    attr.id = SAI_SWITCH_ATTR_TAM_TEL_TYPE_CONFIG_CHANGE_NOTIFY;
+    attr.value.ptr = (void *)on_tam_tel_type_config_change;
+    if (sai_switch_api->set_switch_attribute(gSwitchId, &attr) != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to set SAI_SWITCH_ATTR_TAM_TEL_TYPE_CONFIG_CHANGE_NOTIFY");
+        throw runtime_error("HFTelOrch initialization failure (failed to set tam tel type config change notify)");
+    }
+
+    Orch::addExecutor(notifier);
+}
+
+HFTelOrch::~HFTelOrch()
+{
+    SWSS_LOG_ENTER();
+
+    m_name_profile_mapping.clear();
+    m_type_profile_mapping.clear();
+
+    deleteTAM();
+    deleteNetlinkChannel();
+}
+
+void HFTelOrch::locallyNotify(const CounterNameMapUpdater::Message &msg)
+{
+    SWSS_LOG_ENTER();
+
+    auto counter_itr = HFTelOrch::SUPPORT_COUNTER_TABLES.find(msg.m_table_name);
+    if (counter_itr == HFTelOrch::SUPPORT_COUNTER_TABLES.end())
+    {
+        SWSS_LOG_WARN("The counter table %s is not supported by high frequency telemetry", msg.m_table_name);
+        return;
+    }
+
+    SWSS_LOG_NOTICE("The counter table %s is updated, operation %d, object %s",
+                    msg.m_table_name,
+                    msg.m_operation,
+                    msg.m_operation == CounterNameMapUpdater::SET ? msg.m_set.m_counter_name : msg.m_del.m_counter_name);
+
+    // Update the local cache
+    if (msg.m_operation == CounterNameMapUpdater::SET)
+    {
+        m_counter_name_cache[counter_itr->second][msg.m_set.m_counter_name] = msg.m_set.m_oid;
+    }
+    else if (msg.m_operation == CounterNameMapUpdater::DEL)
+    {
+        m_counter_name_cache[counter_itr->second].erase(msg.m_del.m_counter_name);
+    }
+
+    // Update the profile
+    auto type_itr = m_type_profile_mapping.find(counter_itr->second);
+    if (type_itr == m_type_profile_mapping.end())
+    {
+        return;
+    }
+    for (auto profile_itr = type_itr->second.begin(); profile_itr != type_itr->second.end(); profile_itr++)
+    {
+        auto profile = *profile_itr;
+        const char *counter_name = msg.m_operation == CounterNameMapUpdater::SET ? msg.m_set.m_counter_name : msg.m_del.m_counter_name;
+
+        if (!profile->canBeUpdated(counter_itr->second))
+        {
+            // TODO: Here is a potential issue, we might need to retry the task.
+            // Because the Syncd is generating the configuration(template),
+            // we cannot update the monitor objects at this time.
+            SWSS_LOG_WARN("The high frequency telemetry profile %s is not ready to be updated, but the object %s want to be updated", profile->getProfileName().c_str(), counter_name);
+            continue;
+        }
+
+        if (msg.m_operation == CounterNameMapUpdater::SET)
+        {
+            profile->setObjectSAIID(counter_itr->second, counter_name, msg.m_set.m_oid);
+        }
+        else if (msg.m_operation == CounterNameMapUpdater::DEL)
+        {
+            profile->delObjectSAIID(counter_itr->second, counter_name);
+        }
+        else
+        {
+            SWSS_LOG_THROW("Unknown operation type %d", msg.m_operation);
+        }
+        profile->tryCommitConfig(counter_itr->second);
+    }
+}
+
+bool HFTelOrch::isSupportedHFTel(sai_object_id_t switch_id)
+{
+    SWSS_LOG_ENTER();
+
+    sai_stat_st_capability_list_t stats_st_capability;
+    stats_st_capability.count = 0;
+    stats_st_capability.list = nullptr;
+    sai_status_t status = sai_query_stats_st_capability(switch_id, SAI_OBJECT_TYPE_PORT, &stats_st_capability);
+
+    return status == SAI_STATUS_SUCCESS || status == SAI_STATUS_BUFFER_OVERFLOW;
+}
+
+task_process_status HFTelOrch::profileTableSet(const string &profile_name, const vector<FieldValueTuple> &values)
+{
+    SWSS_LOG_ENTER();
+    auto profile = getProfile(profile_name);
+
+    if (!profile->canBeUpdated())
+    {
+        return task_process_status::task_need_retry;
+    }
+
+    auto value_opt = fvsGetValue(values, "stream_state", true);
+    string stream_state = "disable";
+    sai_tam_tel_type_state_t state = SAI_TAM_TEL_TYPE_STATE_STOP_STREAM;
+    if (value_opt)
+    {
+        lexical_convert(*value_opt, state);
+        profile->setStreamState(state);
+        stream_state = *value_opt;
+    }
+
+    value_opt = fvsGetValue(values, "poll_interval", true);
+    uint32_t poll_interval = 0;
+    if (value_opt)
+    {
+        lexical_convert(*value_opt, poll_interval);
+        profile->setPollInterval(poll_interval);
+    }
+
+    SWSS_LOG_NOTICE("The high frequency telemetry profile %s is set (stream_state: %s, poll_interval: %u)",
+                    profile_name.c_str(),
+                    state == SAI_TAM_TEL_TYPE_STATE_START_STREAM ? "enabled" : "disabled",
+                    poll_interval);
+
+    return task_process_status::task_success;
+}
+
+task_process_status HFTelOrch::profileTableDel(const std::string &profile_name)
+{
+    SWSS_LOG_ENTER();
+
+    auto profile_itr = m_name_profile_mapping.find(profile_name);
+    if (profile_itr == m_name_profile_mapping.end())
+    {
+        return task_process_status::task_success;
+    }
+
+    if (!profile_itr->second->canBeUpdated())
+    {
+        return task_process_status::task_need_retry;
+    }
+
+    if (!profile_itr->second->isEmpty())
+    {
+        return task_process_status::task_need_retry;
+    }
+
+    m_name_profile_mapping.erase(profile_itr);
+
+    SWSS_LOG_NOTICE("The high frequency telemetry profile %s is deleted", profile_name.c_str());
+
+    return task_process_status::task_success;
+}
+
+task_process_status HFTelOrch::groupTableSet(const std::string &profile_name, const std::string &group_name, const std::vector<swss::FieldValueTuple> &values)
+{
+    SWSS_LOG_ENTER();
+
+    auto profile = tryGetProfile(profile_name);
+    if (!profile)
+    {
+        return task_process_status::task_need_retry;
+    }
+
+    auto type = HFTelUtils::group_name_to_sai_type(group_name);
+
+    if (!profile->canBeUpdated(type))
+    {
+        return task_process_status::task_need_retry;
+    }
+
+    auto arg_object_names = fvsGetValue(values, "object_names", true);
+    if (arg_object_names)
+    {
+        vector<string> buffer;
+        boost::split(buffer, *arg_object_names, boost::is_any_of(","));
+        set<string> object_names(buffer.begin(), buffer.end());
+        profile->setObjectNames(group_name, move(object_names));
+    }
+
+    auto arg_object_counters = fvsGetValue(values, "object_counters", true);
+    if (arg_object_counters)
+    {
+        vector<string> buffer;
+        boost::split(buffer, *arg_object_counters, boost::is_any_of(","));
+        set<string> object_counters(buffer.begin(), buffer.end());
+        profile->setStatsIDs(group_name, object_counters);
+    }
+
+    if (profile->getStreamState(type) != SAI_TAM_TEL_TYPE_STATE_STOP_STREAM)
+    {
+        SWSS_LOG_WARN("The high frequency telemetry group %s:%s is not in the stop stream state, it means no new configuration needs to be applied",
+                    profile_name.c_str(),
+                    group_name.c_str());
+        return task_process_status::task_success;
+    }
+
+    profile->tryCommitConfig(type);
+
+    m_type_profile_mapping[type].insert(profile);
+
+    SWSS_LOG_NOTICE("The high frequency telemetry group %s with profile %s is set (object_names: %s, object_counters: %s)",
+                    group_name.c_str(),
+                    profile_name.c_str(),
+                    arg_object_names ? arg_object_names->c_str() : "",
+                    arg_object_counters ? arg_object_counters->c_str() : "");
+
+    return task_process_status::task_success;
+}
+
+task_process_status HFTelOrch::groupTableDel(const std::string &profile_name, const std::string &group_name)
+{
+    SWSS_LOG_ENTER();
+
+    auto profile = tryGetProfile(profile_name);
+
+    if (!profile)
+    {
+        SWSS_LOG_WARN("The high frequency telemetry profile %s is not found", profile_name.c_str());
+        return task_process_status::task_success;
+    }
+
+    auto type = HFTelUtils::group_name_to_sai_type(group_name);
+
+    if (!profile->canBeUpdated(type))
+    {
+        return task_process_status::task_need_retry;
+    }
+
+    profile->clearGroup(group_name);
+    m_type_profile_mapping[type].erase(profile);
+    m_state_telemetry_session.del(profile_name + "|" + group_name);
+
+    SWSS_LOG_NOTICE("The high frequency telemetry group %s with profile %s is deleted", group_name.c_str(), profile_name.c_str());
+
+    return task_process_status::task_success;
+}
+
+shared_ptr<HFTelProfile> HFTelOrch::getProfile(const string &profile_name)
+{
+    SWSS_LOG_ENTER();
+
+    if (m_name_profile_mapping.find(profile_name) == m_name_profile_mapping.end())
+    {
+        m_name_profile_mapping.emplace(
+            profile_name,
+            make_shared<HFTelProfile>(
+                profile_name,
+                m_sai_tam_obj,
+                m_sai_tam_collector_obj,
+                m_counter_name_cache));
+    }
+
+    return m_name_profile_mapping.at(profile_name);
+}
+
+std::shared_ptr<HFTelProfile> HFTelOrch::tryGetProfile(const std::string &profile_name)
+{
+    SWSS_LOG_ENTER();
+
+    auto itr = m_name_profile_mapping.find(profile_name);
+    if (itr != m_name_profile_mapping.end())
+    {
+        return itr->second;
+    }
+
+    return std::shared_ptr<HFTelProfile>();
+}
+
+void HFTelOrch::doTask(swss::NotificationConsumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    std::string op;
+    std::string data;
+    std::vector<swss::FieldValueTuple> values;
+
+    if (&consumer != m_asic_notification_consumer.get())
+    {
+        SWSS_LOG_DEBUG("Is not TAM notification");
+        return;
+    }
+
+    consumer.pop(op, data, values);
+
+    if (op != SAI_SWITCH_NOTIFICATION_NAME_TAM_TEL_TYPE_CONFIG_CHANGE)
+    {
+        SWSS_LOG_DEBUG("Unknown operation type %s for HFTel Orch", op.c_str());
+        return;
+    }
+
+    sai_object_id_t tam_tel_type_obj = SAI_NULL_OBJECT_ID;
+
+    sai_deserialize_object_id(data, tam_tel_type_obj);
+
+    if (tam_tel_type_obj == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_ERROR("The TAM tel type object is not valid");
+        return;
+    }
+
+    for (auto &profile : m_name_profile_mapping)
+    {
+        auto type = profile.second->getObjectType(tam_tel_type_obj);
+        if (type == SAI_OBJECT_TYPE_NULL)
+        {
+            continue;
+        }
+
+        // TODO: A potential optimization
+        // We need to notify Config Ready only when the message of State DB is delivered to the CounterSyncd
+        profile.second->notifyConfigReady(type);
+
+        // Update state db
+        vector<FieldValueTuple> values;
+        auto state = profile.second->getTelemetryTypeState(type);
+        if (state == SAI_TAM_TEL_TYPE_STATE_START_STREAM)
+        {
+            values.emplace_back("stream_status", "enabled");
+        }
+        else if (state == SAI_TAM_TEL_TYPE_STATE_STOP_STREAM)
+        {
+            values.emplace_back("stream_status", "disabled");
+        }
+        else
+        {
+            SWSS_LOG_THROW("Unexpected state %d for high frequency telemetry", state);
+        }
+
+
+        values.emplace_back("object_names", boost::algorithm::join(profile.second->getObjectNames(type), ","));
+        auto to_string = boost::adaptors::transformed([](sai_uint16_t n)
+                                                        { return boost::lexical_cast<std::string>(n); });
+        values.emplace_back("object_ids", boost::algorithm::join(profile.second->getObjectLabels(type) | to_string, ","));
+
+
+        values.emplace_back("session_type", "ipfix");
+
+        auto templates = profile.second->getTemplates(type);
+        values.emplace_back("session_config", string(templates.begin(), templates.end()));
+
+        m_state_telemetry_session.set(profile.first + "|" + HFTelUtils::sai_type_to_group_name(type), values);
+
+        SWSS_LOG_NOTICE("The high frequency telemetry group %s with profile %s is ready",
+                        HFTelUtils::sai_type_to_group_name(type).c_str(),
+                        profile.first.c_str());
+
+        return;
+    }
+
+    SWSS_LOG_ERROR("The TAM tel type object %s is not found in the profile", sai_serialize_object_id(tam_tel_type_obj).c_str());
+}
+
+void HFTelOrch::doTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    string table_name = consumer.getTableName();
+
+    auto itr = consumer.m_toSync.begin();
+    while (itr != consumer.m_toSync.end())
+    {
+        task_process_status status = task_process_status::task_failed;
+        KeyOpFieldsValuesTuple t = itr->second;
+
+        string key = kfvKey(t);
+        string op = kfvOp(t);
+
+        if (table_name == CFG_HIGH_FREQUENCY_TELEMETRY_PROFILE_TABLE_NAME)
+        {
+            if (op == SET_COMMAND)
+            {
+                status = profileTableSet(key, kfvFieldsValues(t));
+            }
+            else if (op == DEL_COMMAND)
+            {
+                status = profileTableDel(key);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown operation type %s\n", op.c_str());
+            }
+        }
+        else if (table_name == CFG_HIGH_FREQUENCY_TELEMETRY_GROUP_TABLE_NAME)
+        {
+            auto tokens = tokenize(key, '|');
+            if (tokens.size() != 2)
+            {
+                SWSS_LOG_THROW("Invalid key %s in the %s", key.c_str(), table_name.c_str());
+            }
+            if (op == SET_COMMAND)
+            {
+                status = groupTableSet(tokens[0], tokens[1], kfvFieldsValues(t));
+            }
+            else if (op == DEL_COMMAND)
+            {
+                status = groupTableDel(tokens[0], tokens[1]);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown operation type %s\n", op.c_str());
+            }
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Unknown table %s\n", table_name.c_str());
+        }
+
+        if (status == task_process_status::task_need_retry)
+        {
+            ++itr;
+        }
+        else
+        {
+            itr = consumer.m_toSync.erase(itr);
+        }
+    }
+}
+
+void HFTelOrch::createNetlinkChannel(const string &genl_family, const string &genl_group)
+{
+    SWSS_LOG_ENTER();
+
+    // Delete the existing netlink channel
+    deleteNetlinkChannel();
+
+    vector<sai_attribute_t> attrs;
+    sai_attribute_t attr;
+
+    // Create hostif object
+    attr.id = SAI_HOSTIF_ATTR_TYPE;
+    attr.value.s32 = SAI_HOSTIF_TYPE_GENETLINK;
+    attrs.push_back(attr);
+
+    attr.id = SAI_HOSTIF_ATTR_OPER_STATUS;
+    attr.value.booldata = true;
+    attrs.push_back(attr);
+
+    attr.id = SAI_HOSTIF_ATTR_NAME;
+    strncpy(attr.value.chardata, genl_family.c_str(), sizeof(attr.value.chardata));
+    attrs.push_back(attr);
+
+    attr.id = SAI_HOSTIF_ATTR_GENETLINK_MCGRP_NAME;
+    strncpy(attr.value.chardata, genl_group.c_str(), sizeof(attr.value.chardata));
+    attrs.push_back(attr);
+
+    sai_hostif_api->create_hostif(&m_sai_hostif_obj, gSwitchId, static_cast<uint32_t>(attrs.size()), attrs.data());
+
+    // // Create hostif trap group object
+    // sai_hostif_api->create_hostif_trap_group(&m_sai_hostif_trap_group_obj, gSwitchId, 0, nullptr);
+
+    // Create hostif user defined trap object
+    attrs.clear();
+
+    attr.id = SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_TYPE;
+    attr.value.s32 = SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_TAM;
+    attrs.push_back(attr);
+
+    // attr.id = SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_TRAP_GROUP;
+    // attr.value.oid = m_sai_hostif_trap_group_obj;
+    // attrs.push_back(attr);
+
+    sai_hostif_api->create_hostif_user_defined_trap(&m_sai_hostif_user_defined_trap_obj, gSwitchId, static_cast<uint32_t>(attrs.size()), attrs.data());
+
+    // Create hostif table entry object
+    attrs.clear();
+
+    attr.id = SAI_HOSTIF_TABLE_ENTRY_ATTR_TYPE;
+    attr.value.s32 = SAI_HOSTIF_TABLE_ENTRY_TYPE_TRAP_ID;
+    attrs.push_back(attr);
+
+    attr.id = SAI_HOSTIF_TABLE_ENTRY_ATTR_TRAP_ID;
+    attr.value.oid = m_sai_hostif_user_defined_trap_obj;
+    attrs.push_back(attr);
+
+    attr.id = SAI_HOSTIF_TABLE_ENTRY_ATTR_CHANNEL_TYPE;
+    attr.value.s32 = SAI_HOSTIF_TABLE_ENTRY_CHANNEL_TYPE_GENETLINK;
+    attrs.push_back(attr);
+
+    attr.id = SAI_HOSTIF_TABLE_ENTRY_ATTR_HOST_IF;
+    attr.value.oid = m_sai_hostif_obj;
+    attrs.push_back(attr);
+
+    sai_hostif_api->create_hostif_table_entry(&m_sai_hostif_table_entry_obj, gSwitchId, static_cast<uint32_t>(attrs.size()), attrs.data());
+}
+
+void HFTelOrch::deleteNetlinkChannel()
+{
+    SWSS_LOG_ENTER();
+
+    if (m_sai_hostif_table_entry_obj != SAI_NULL_OBJECT_ID)
+    {
+        sai_hostif_api->remove_hostif_table_entry(m_sai_hostif_table_entry_obj);
+        m_sai_hostif_table_entry_obj = SAI_NULL_OBJECT_ID;
+    }
+    if (m_sai_hostif_user_defined_trap_obj != SAI_NULL_OBJECT_ID)
+    {
+        sai_hostif_api->remove_hostif_user_defined_trap(m_sai_hostif_user_defined_trap_obj);
+        m_sai_hostif_user_defined_trap_obj = SAI_NULL_OBJECT_ID;
+    }
+    if (m_sai_hostif_trap_group_obj != SAI_NULL_OBJECT_ID)
+    {
+        sai_hostif_api->remove_hostif_trap_group(m_sai_hostif_trap_group_obj);
+        m_sai_hostif_trap_group_obj = SAI_NULL_OBJECT_ID;
+    }
+    if (m_sai_hostif_obj != SAI_NULL_OBJECT_ID)
+    {
+        sai_hostif_api->remove_hostif(m_sai_hostif_obj);
+        m_sai_hostif_obj = SAI_NULL_OBJECT_ID;
+    }
+}
+
+void HFTelOrch::createTAM()
+{
+    SWSS_LOG_ENTER();
+
+    // Delete the existing TAM
+    deleteTAM();
+
+    vector<sai_attribute_t> attrs;
+    sai_attribute_t attr;
+
+    // Create TAM transport object
+    attr.id = SAI_TAM_TRANSPORT_ATTR_TRANSPORT_TYPE;
+    attr.value.s32 = SAI_TAM_TRANSPORT_TYPE_NONE;
+    attrs.push_back(attr);
+
+    handleSaiCreateStatus(
+        SAI_API_TAM,
+        sai_tam_api->create_tam_transport(
+            &m_sai_tam_transport_obj,
+            gSwitchId,
+            static_cast<uint32_t>(attrs.size()),
+            attrs.data()));
+
+    // Create TAM collector object
+    attrs.clear();
+
+    attr.id = SAI_TAM_COLLECTOR_ATTR_SRC_IP;
+    attr.value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    attr.value.ipaddr.addr.ip4 = 0;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_COLLECTOR_ATTR_DST_IP;
+    attr.value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    attr.value.ipaddr.addr.ip4 = 0;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_COLLECTOR_ATTR_TRANSPORT;
+    attr.value.oid = m_sai_tam_transport_obj;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_COLLECTOR_ATTR_LOCALHOST;
+    attr.value.booldata = true;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_COLLECTOR_ATTR_HOSTIF_TRAP;
+    attr.value.oid = m_sai_hostif_user_defined_trap_obj;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_COLLECTOR_ATTR_DSCP_VALUE;
+    attr.value.u8 = 0;
+    attrs.push_back(attr);
+
+    handleSaiCreateStatus(
+        SAI_API_TAM,
+        sai_tam_api->create_tam_collector(
+            &m_sai_tam_collector_obj,
+            gSwitchId,
+            static_cast<uint32_t>(attrs.size()),
+            attrs.data()));
+
+    // Create TAM object
+    attrs.clear();
+    attr.id = SAI_TAM_ATTR_TAM_BIND_POINT_TYPE_LIST;
+    vector<sai_int32_t> bind_point_types = {
+        SAI_TAM_BIND_POINT_TYPE_SWITCH,
+    };
+    attr.value.s32list.count = static_cast<uint32_t>(bind_point_types.size());
+    attr.value.s32list.list = bind_point_types.data();
+    attrs.push_back(attr);
+
+    handleSaiCreateStatus(
+        SAI_API_TAM,
+        sai_tam_api->create_tam(
+            &m_sai_tam_obj,
+            gSwitchId,
+            static_cast<uint32_t>(attrs.size()),
+            attrs.data()));
+
+    // Bind the TAM object to switch
+    // FIX: There is a bug for config reload
+    // WARNING #syncd: :- logViewObjectCount: object count for SAI_OBJECT_TYPE_TAM on current view 1 is different than on temporary view: 2
+    // WARNING #syncd: :- performObjectSetTransition: Present current attr SAI_TAM_ATTR_TAM_BIND_POINT_TYPE_LIST:1:SAI_TAM_BIND_POINT_TYPE_SWITCH has default that CAN'T be set to 0:null since it's CREATE_ONLY
+    attr.id = SAI_SWITCH_ATTR_TAM_OBJECT_ID;
+    vector<sai_object_id_t> obj_list = {m_sai_tam_obj};
+    attr.value.objlist.count = static_cast<uint32_t>(obj_list.size());
+    attr.value.objlist.list = obj_list.data();
+    sai_status_t status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to set SAI_SWITCH_ATTR_TAM_OBJECT_ID, status: %s",
+                       sai_serialize_status(status).c_str());
+        throw runtime_error("HFTelOrch initialization failure (failed to set tam object id)");
+    }
+}
+
+void HFTelOrch::deleteTAM()
+{
+    SWSS_LOG_ENTER();
+
+    if (m_sai_tam_obj != SAI_NULL_OBJECT_ID)
+    {
+        // Unbind the TAM object from switch
+        HFTELUTILS_DEL_SAI_OBJECT_LIST(
+            gSwitchId,
+            SAI_SWITCH_ATTR_TAM_OBJECT_ID,
+            m_sai_tam_obj,
+            SAI_API_SWITCH,
+            switch,
+            switch);
+        handleSaiRemoveStatus(
+            SAI_API_TAM,
+            sai_tam_api->remove_tam(m_sai_tam_obj));
+        m_sai_tam_obj = SAI_NULL_OBJECT_ID;
+    }
+    if (m_sai_tam_collector_obj != SAI_NULL_OBJECT_ID)
+    {
+        handleSaiRemoveStatus(
+            SAI_API_TAM,
+            sai_tam_api->remove_tam_collector(m_sai_tam_collector_obj));
+        m_sai_tam_collector_obj = SAI_NULL_OBJECT_ID;
+    }
+    if (m_sai_tam_transport_obj != SAI_NULL_OBJECT_ID)
+    {
+        handleSaiRemoveStatus(
+            SAI_API_TAM,
+            sai_tam_api->remove_tam_transport(m_sai_tam_transport_obj));
+        m_sai_tam_transport_obj = SAI_NULL_OBJECT_ID;
+    }
+}

--- a/orchagent/high_frequency_telemetry/hftelorch.h
+++ b/orchagent/high_frequency_telemetry/hftelorch.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <saitypes.h>
+#include <orch.h>
+
+#include <vector>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <memory>
+
+#include "counternameupdater.h"
+#include "hftelprofile.h"
+
+
+class HFTelOrch : public Orch
+{
+public:
+    HFTelOrch(
+        swss::DBConnector *cfg_db,
+        swss::DBConnector *state_db,
+        const std::vector<std::string> &tables);
+    ~HFTelOrch();
+    HFTelOrch(const HFTelOrch &) = delete;
+    HFTelOrch &operator=(const HFTelOrch &) = delete;
+    HFTelOrch(HFTelOrch &&) = delete;
+    HFTelOrch &operator=(HFTelOrch &&) = delete;
+
+    static const std::unordered_map<std::string, sai_object_type_t> SUPPORT_COUNTER_TABLES;
+
+    void locallyNotify(const CounterNameMapUpdater::Message &msg);
+    static bool isSupportedHFTel(sai_object_id_t switch_id);
+
+private:
+    swss::Table m_state_telemetry_session;
+    swss::DBConnector m_asic_db;
+    std::shared_ptr<swss::NotificationConsumer> m_asic_notification_consumer;
+
+    std::unordered_map<std::string, std::shared_ptr<HFTelProfile>> m_name_profile_mapping;
+    std::unordered_map<sai_object_type_t, std::unordered_set<std::shared_ptr<HFTelProfile>>> m_type_profile_mapping;
+    CounterNameCache m_counter_name_cache;
+
+    task_process_status profileTableSet(const std::string &profile_name, const std::vector<swss::FieldValueTuple> &values);
+    task_process_status profileTableDel(const std::string &profile_name);
+    task_process_status groupTableSet(const std::string &profile_name, const std::string &group_name, const std::vector<swss::FieldValueTuple> &values);
+    task_process_status groupTableDel(const std::string &profile_name, const std::string &group_name);
+    std::shared_ptr<HFTelProfile> getProfile(const std::string &profile_name);
+    std::shared_ptr<HFTelProfile> tryGetProfile(const std::string &profile_name);
+
+    void doTask(swss::NotificationConsumer &consumer);
+    void doTask(Consumer &consumer);
+
+    // SAI objects
+    sai_object_id_t m_sai_hostif_obj;
+    sai_object_id_t m_sai_hostif_trap_group_obj;
+    sai_object_id_t m_sai_hostif_user_defined_trap_obj;
+    sai_object_id_t m_sai_hostif_table_entry_obj;
+    sai_object_id_t m_sai_tam_transport_obj;
+    sai_object_id_t m_sai_tam_collector_obj;
+    sai_object_id_t m_sai_tam_obj;
+
+    // SAI calls
+    void createNetlinkChannel(const std::string &genl_family, const std::string &genl_group);
+    void deleteNetlinkChannel();
+    void createTAM();
+    void deleteTAM();
+};

--- a/orchagent/high_frequency_telemetry/hftelprofile.cpp
+++ b/orchagent/high_frequency_telemetry/hftelprofile.cpp
@@ -1,0 +1,984 @@
+#include "hftelprofile.h"
+#include "hftelutils.h"
+#include "saihelper.h"
+
+#include <swss/logger.h>
+#include <swss/redisutility.h>
+#include <sai_serialize.h>
+
+#include <boost/tokenizer.hpp>
+#include <boost/algorithm/string.hpp>
+
+using namespace std;
+using namespace swss;
+
+extern sai_object_id_t gSwitchId;
+extern sai_tam_api_t *sai_tam_api;
+
+HFTelProfile::HFTelProfile(
+    const string &profile_name,
+    sai_object_id_t sai_tam_obj,
+    sai_object_id_t sai_tam_collector_obj,
+    const CounterNameCache &cache)
+    : m_profile_name(profile_name),
+      m_setting_state(SAI_TAM_TEL_TYPE_STATE_STOP_STREAM),
+      m_poll_interval(0),
+      m_counter_name_cache(cache),
+      m_sai_tam_obj(sai_tam_obj),
+      m_sai_tam_collector_obj(sai_tam_collector_obj)
+{
+    SWSS_LOG_ENTER();
+
+    if (m_sai_tam_obj == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_THROW("The SAI TAM object is not valid");
+    }
+    if (m_sai_tam_collector_obj == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_THROW("The SAI TAM collector object is not valid");
+    }
+
+    initTelemetry();
+}
+
+HFTelProfile::~HFTelProfile()
+{
+    SWSS_LOG_ENTER();
+}
+
+const string &HFTelProfile::getProfileName() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_profile_name;
+}
+
+void HFTelProfile::setStreamState(sai_tam_tel_type_state_t state)
+{
+    SWSS_LOG_ENTER();
+    m_setting_state = state;
+
+    for (const auto &item : m_sai_tam_tel_type_objs)
+    {
+        setStreamState(item.first, state);
+    }
+}
+
+void HFTelProfile::setStreamState(sai_object_type_t type, sai_tam_tel_type_state_t state)
+{
+    SWSS_LOG_ENTER();
+
+    auto type_itr = m_sai_tam_tel_type_objs.find(type);
+    if (type_itr == m_sai_tam_tel_type_objs.end())
+    {
+        return;
+    }
+
+    auto stats = m_sai_tam_tel_type_states.find(type_itr->second);
+    if (stats == m_sai_tam_tel_type_states.end())
+    {
+        return;
+    }
+
+    if (stats->second == state)
+    {
+        return;
+    }
+
+    do
+    {
+        if (stats->second == SAI_TAM_TEL_TYPE_STATE_STOP_STREAM)
+        {
+            if (state == SAI_TAM_TEL_TYPE_STATE_CREATE_CONFIG)
+            {
+                if (!isMonitoringObjectReady(type))
+                {
+                    return;
+                }
+                // Clearup the previous templates
+                m_sai_tam_tel_type_templates.erase(type);
+            }
+            else if (state == SAI_TAM_TEL_TYPE_STATE_START_STREAM)
+            {
+                if (m_sai_tam_tel_type_templates.find(type) == m_sai_tam_tel_type_templates.end())
+                {
+                    // The template isn't ready
+                    return;
+                }
+                if (!isMonitoringObjectReady(type))
+                {
+                    return;
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+        else if (stats->second == SAI_TAM_TEL_TYPE_STATE_START_STREAM)
+        {
+            if (state == SAI_TAM_TEL_TYPE_STATE_STOP_STREAM)
+            {
+                // Nothing to do
+            }
+            else if (state == SAI_TAM_TEL_TYPE_STATE_CREATE_CONFIG)
+            {
+                // TODO: Implement the transition from started to config generating in Phase2
+                SWSS_LOG_THROW("Transfer from start to create config hasn't been implemented yet");
+            }
+            else
+            {
+                break;
+            }
+        }
+        else if (stats->second == SAI_TAM_TEL_TYPE_STATE_CREATE_CONFIG)
+        {
+            if (state == SAI_TAM_TEL_TYPE_STATE_STOP_STREAM)
+            {
+                // Nothing to do
+            }
+            else if (state == SAI_TAM_TEL_TYPE_STATE_START_STREAM)
+            {
+                // Nothing to do
+            }
+            else
+            {
+                break;
+            }
+        }
+        else
+        {
+            SWSS_LOG_THROW("Unknown state %d", stats->second);
+        }
+
+        sai_attribute_t attr;
+        attr.id = SAI_TAM_TEL_TYPE_ATTR_STATE;
+        attr.value.s32 = state;
+        auto status = sai_tam_api->set_tam_tel_type_attribute(*type_itr->second, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            handleSaiSetStatus(SAI_API_TAM, status);
+        }
+
+        stats->second = state;
+        return;
+
+    } while(false);
+
+    SWSS_LOG_THROW("Invalid state transfer from %d to %d", stats->second, state);
+}
+
+sai_tam_tel_type_state_t HFTelProfile::getStreamState(sai_object_type_t object_type) const
+{
+    SWSS_LOG_ENTER();
+    auto itr = m_sai_tam_tel_type_objs.find(object_type);
+    if (itr == m_sai_tam_tel_type_objs.end())
+    {
+        return SAI_TAM_TEL_TYPE_STATE_STOP_STREAM;
+    }
+    auto state_itr = m_sai_tam_tel_type_states.find(itr->second);
+    if (state_itr == m_sai_tam_tel_type_states.end())
+    {
+        return SAI_TAM_TEL_TYPE_STATE_STOP_STREAM;
+    }
+    return state_itr->second;
+}
+
+void HFTelProfile::notifyConfigReady(sai_object_type_t object_type)
+{
+    SWSS_LOG_ENTER();
+
+    auto itr = m_sai_tam_tel_type_objs.find(object_type);
+    if (itr == m_sai_tam_tel_type_objs.end())
+    {
+        return;
+    }
+
+    updateTemplates(*itr->second);
+    setStreamState(object_type, m_setting_state);
+}
+
+sai_tam_tel_type_state_t HFTelProfile::getTelemetryTypeState(sai_object_type_t object_type) const
+{
+    SWSS_LOG_ENTER();
+
+    auto itr = m_sai_tam_tel_type_objs.find(object_type);
+    if (itr == m_sai_tam_tel_type_objs.end())
+    {
+        return SAI_TAM_TEL_TYPE_STATE_STOP_STREAM;
+    }
+    auto state_itr = m_sai_tam_tel_type_states.find(itr->second);
+    if (state_itr == m_sai_tam_tel_type_states.end())
+    {
+        return SAI_TAM_TEL_TYPE_STATE_STOP_STREAM;
+    }
+    return state_itr->second;
+}
+
+HFTelProfile::sai_guard_t HFTelProfile::getTAMTelTypeGuard(sai_object_id_t tam_tel_type_obj) const
+{
+    SWSS_LOG_ENTER();
+
+    for (const auto &item : m_sai_tam_tel_type_objs)
+    {
+        if (*item.second == tam_tel_type_obj)
+        {
+            return item.second;
+        }
+    }
+
+    return sai_guard_t();
+}
+
+sai_object_type_t HFTelProfile::getObjectType(sai_object_id_t tam_tel_type_obj) const
+{
+    SWSS_LOG_ENTER();
+
+    auto guard = getTAMTelTypeGuard(tam_tel_type_obj);
+    if (guard)
+    {
+        for (const auto &item : m_sai_tam_tel_type_objs)
+        {
+            if (item.second == guard)
+            {
+                return item.first;
+            }
+        }
+    }
+
+    return SAI_OBJECT_TYPE_NULL;
+}
+
+void HFTelProfile::setPollInterval(uint32_t poll_interval)
+{
+    SWSS_LOG_ENTER();
+
+    if (poll_interval == m_poll_interval)
+    {
+        return;
+    }
+    m_poll_interval = poll_interval;
+
+    for (const auto &report : m_sai_tam_report_objs)
+    {
+        sai_attribute_t attr;
+        attr.id = SAI_TAM_REPORT_ATTR_REPORT_INTERVAL;
+        attr.value.u32 = m_poll_interval;
+        sai_status_t status = sai_tam_api->set_tam_report_attribute(*report.second, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            handleSaiSetStatus(SAI_API_TAM, status);
+        }
+    }
+}
+
+void HFTelProfile::setObjectNames(const string &group_name, set<string> &&object_names)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_type_t sai_object_type = HFTelUtils::group_name_to_sai_type(group_name);
+
+    auto itr = m_groups.lower_bound(sai_object_type);
+
+    if (itr == m_groups.end() || itr->first != sai_object_type)
+    {
+        HFTelGroup group(group_name);
+        group.updateObjects(object_names);
+        m_groups.insert(itr, {sai_object_type, move(group)});
+    }
+    else
+    {
+        if (itr->second.isSameObjects(object_names))
+        {
+            return;
+        }
+        for (const auto &obj : itr->second.getObjects())
+        {
+            delObjectSAIID(sai_object_type, obj.first.c_str());
+        }
+        itr->second.updateObjects(object_names);
+    }
+    loadCounterNameCache(sai_object_type);
+
+    // TODO: In the phase 2, we don't need to stop the stream before update the object names
+    setStreamState(sai_object_type, SAI_TAM_TEL_TYPE_STATE_STOP_STREAM);
+}
+
+void HFTelProfile::setStatsIDs(const string &group_name, const set<string> &object_counters)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_type_t sai_object_type = HFTelUtils::group_name_to_sai_type(group_name);
+    auto itr = m_groups.lower_bound(sai_object_type);
+    set<sai_stat_id_t> stats_ids_set = HFTelUtils::object_counters_to_stats_ids(group_name, object_counters);
+
+    if (itr == m_groups.end() || itr->first != sai_object_type)
+    {
+        HFTelGroup group(group_name);
+        group.updateStatsIDs(stats_ids_set);
+        m_groups.insert(itr, {sai_object_type, move(group)});
+    }
+    else
+    {
+        if (itr->second.getStatsIDs() == stats_ids_set)
+        {
+            return;
+        }
+        itr->second.updateStatsIDs(stats_ids_set);
+    }
+
+    // TODO: In the phase 2, we don't need to stop the stream before update the stats
+    setStreamState(sai_object_type, SAI_TAM_TEL_TYPE_STATE_STOP_STREAM);
+
+    deployCounterSubscriptions(sai_object_type);
+}
+
+void HFTelProfile::setObjectSAIID(sai_object_type_t object_type, const char *object_name, sai_object_id_t object_id)
+{
+    SWSS_LOG_ENTER();
+
+    if (!isObjectTypeInProfile(object_type, object_name))
+    {
+        return;
+    }
+
+    auto &objs = m_name_sai_map[object_type];
+    auto itr = objs.find(object_name);
+    if (itr != objs.end())
+    {
+        if (itr->second == object_id)
+        {
+            return;
+        }
+    }
+    objs[object_name] = object_id;
+
+    SWSS_LOG_DEBUG("Set object %s with ID %s in the name sai map", object_name, sai_serialize_object_id(object_id).c_str());
+
+    // TODO: In the phase 2, we don't need to stop the stream before update the object
+    setStreamState(object_type, SAI_TAM_TEL_TYPE_STATE_STOP_STREAM);
+
+    // Update the counter subscription
+    deployCounterSubscriptions(object_type, object_id, m_groups.at(object_type).getObjects().at(object_name));
+}
+
+void HFTelProfile::delObjectSAIID(sai_object_type_t object_type, const char *object_name)
+{
+    SWSS_LOG_ENTER();
+
+    if (!isObjectTypeInProfile(object_type, object_name))
+    {
+        return;
+    }
+
+    auto &objs = m_name_sai_map[object_type];
+    auto itr = objs.find(object_name);
+    if (itr == objs.end())
+    {
+        return;
+    }
+
+    // TODO: In the phase 2, we don't need to stop the stream before removing the object
+    setStreamState(object_type, SAI_TAM_TEL_TYPE_STATE_STOP_STREAM);
+
+    // Remove all counters bounded to the object
+    auto counter_itr = m_sai_tam_counter_subscription_objs.find(object_type);
+    if (counter_itr != m_sai_tam_counter_subscription_objs.end())
+    {
+        counter_itr->second.erase(itr->second);
+        if (counter_itr->second.empty())
+        {
+            m_sai_tam_counter_subscription_objs.erase(counter_itr);
+        }
+    }
+
+    objs.erase(itr);
+    if (objs.empty())
+    {
+        m_name_sai_map.erase(object_type);
+        SWSS_LOG_DEBUG("Delete object %s from the name sai map", object_name);
+    }
+}
+
+bool HFTelProfile::canBeUpdated() const
+{
+    SWSS_LOG_ENTER();
+
+    for (const auto &group : m_groups)
+    {
+        if (!canBeUpdated(group.first))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool HFTelProfile::canBeUpdated(sai_object_type_t object_type) const
+{
+    SWSS_LOG_ENTER();
+
+
+    if (getTelemetryTypeState(object_type) == SAI_TAM_TEL_TYPE_STATE_CREATE_CONFIG)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool HFTelProfile::isEmpty() const
+{
+    SWSS_LOG_ENTER();
+
+    return m_groups.empty();
+}
+
+void HFTelProfile::clearGroup(const std::string &group_name)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_type_t sai_object_type = HFTelUtils::group_name_to_sai_type(group_name);
+
+    auto itr = m_groups.find(sai_object_type);
+    if (itr != m_groups.end())
+    {
+        for (const auto &obj : itr->second.getObjects())
+        {
+            delObjectSAIID(sai_object_type, obj.first.c_str());
+        }
+        m_groups.erase(itr);
+    }
+    m_sai_tam_tel_type_templates.erase(sai_object_type);
+    m_sai_tam_tel_type_states.erase(m_sai_tam_tel_type_objs[sai_object_type]);
+    m_sai_tam_tel_type_objs.erase(sai_object_type);
+    m_sai_tam_report_objs.erase(sai_object_type);
+    m_sai_tam_counter_subscription_objs.erase(sai_object_type);
+    m_name_sai_map.erase(sai_object_type);
+
+    SWSS_LOG_NOTICE("Cleared high frequency telemetry group %s with no objects", group_name.c_str());
+}
+
+const vector<uint8_t> &HFTelProfile::getTemplates(sai_object_type_t object_type) const
+{
+    SWSS_LOG_ENTER();
+
+    return m_sai_tam_tel_type_templates.at(object_type);
+}
+
+const vector<string> HFTelProfile::getObjectNames(sai_object_type_t object_type) const
+{
+    SWSS_LOG_ENTER();
+
+    vector<string> object_names;
+    auto group = m_groups.find(object_type);
+    if (group != m_groups.end())
+    {
+        object_names.resize(group->second.getObjects().size());
+        transform(group->second.getObjects().begin(), group->second.getObjects().end(), object_names.begin(),
+                  [](const auto &pair)
+                  { return pair.first; });
+    }
+
+    return object_names;
+}
+
+const vector<uint16_t> HFTelProfile::getObjectLabels(sai_object_type_t object_type) const
+{
+    SWSS_LOG_ENTER();
+
+    vector<uint16_t> object_labels;
+    auto group = m_groups.find(object_type);
+    if (group != m_groups.end())
+    {
+        object_labels.resize(group->second.getObjects().size());
+        transform(group->second.getObjects().begin(), group->second.getObjects().end(), object_labels.begin(),
+                  [](const auto &pair)
+                  { return pair.second; });
+    }
+    return object_labels;
+}
+
+pair<vector<string>, vector<string>> HFTelProfile::getObjectNamesAndLabels(sai_object_type_t object_type) const
+{
+    SWSS_LOG_ENTER();
+
+    auto group = m_groups.find(object_type);
+    if (group == m_groups.end())
+    {
+        return {vector<string>(), vector<string>()};
+    }
+
+    return group->second.getObjectNamesAndLabels();
+}
+
+vector<sai_object_type_t> HFTelProfile::getObjectTypes() const
+{
+    vector<sai_object_type_t> types;
+    types.reserve(m_groups.size());
+
+    for (const auto &group : m_groups)
+    {
+        types.push_back(group.first);
+    }
+
+    return types;
+}
+
+void HFTelProfile::loadCounterNameCache(sai_object_type_t object_type)
+{
+    SWSS_LOG_ENTER();
+
+    auto itr = m_counter_name_cache.find(object_type);
+    if (itr == m_counter_name_cache.end())
+    {
+        return;
+    }
+    auto group = m_groups.find(object_type);
+    if (group == m_groups.end())
+    {
+        return;
+    }
+    const auto &sai_objs = itr->second;
+    for (const auto &obj : group->second.getObjects())
+    {
+        auto sai_obj = sai_objs.find(obj.first);
+        if (sai_obj != sai_objs.end())
+        {
+            setObjectSAIID(object_type, obj.first.c_str(), sai_obj->second);
+        }
+    }
+}
+
+bool HFTelProfile::tryCommitConfig(sai_object_type_t object_type)
+{
+    SWSS_LOG_ENTER();
+
+    if (!canBeUpdated(object_type))
+    {
+        return false;
+    }
+
+    if (m_setting_state == SAI_TAM_TEL_TYPE_STATE_CREATE_CONFIG)
+    {
+        SWSS_LOG_THROW("Cannot commit the configuration in the state %d", m_setting_state);
+    }
+
+    auto group = m_groups.find(object_type);
+    if (group == m_groups.end())
+    {
+        return false;
+    }
+    if (group->second.getObjects().empty())
+    {
+        // TODO: If the object names are empty, implicitly select all objects of the group
+        return true;
+    }
+    if (!isMonitoringObjectReady(object_type))
+    {
+        deployCounterSubscriptions(object_type);
+        if (!isMonitoringObjectReady(object_type))
+        {
+            // There are some objects still not ready
+            return false;
+        }
+    }
+    setStreamState(object_type, SAI_TAM_TEL_TYPE_STATE_CREATE_CONFIG);
+    return true;
+}
+
+bool HFTelProfile::isObjectTypeInProfile(sai_object_type_t object_type, const string &object_name) const
+{
+    SWSS_LOG_ENTER();
+
+    auto group = m_groups.find(object_type);
+    if (group == m_groups.end())
+    {
+        return false;
+    }
+    if (!group->second.isObjectInGroup(object_name))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool HFTelProfile::isMonitoringObjectReady(sai_object_type_t object_type) const
+{
+    SWSS_LOG_ENTER();
+
+    auto group = m_groups.find(object_type);
+    if (group == m_groups.end())
+    {
+        SWSS_LOG_THROW("The high frequency telemetry group for object type %s is not found", sai_serialize_object_type(object_type).c_str());
+    }
+
+    auto counters = m_sai_tam_counter_subscription_objs.find(object_type);
+
+    if (counters == m_sai_tam_counter_subscription_objs.end() || group->second.getObjects().size() != counters->second.size())
+    {
+        // The monitoring counters are not ready
+        return false;
+    }
+
+    return true;
+}
+
+sai_object_id_t HFTelProfile::getTAMReportObjID(sai_object_type_t object_type)
+{
+    SWSS_LOG_ENTER();
+
+    auto itr = m_sai_tam_report_objs.find(object_type);
+    if (itr != m_sai_tam_report_objs.end())
+    {
+        return *itr->second;
+    }
+
+    sai_object_id_t sai_object;
+    vector<sai_attribute_t> attrs;
+    sai_attribute_t attr;
+
+    // Create TAM report object
+    attr.id = SAI_TAM_REPORT_ATTR_TYPE;
+    attr.value.s32 = SAI_TAM_REPORT_TYPE_IPFIX;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_REPORT_ATTR_REPORT_MODE;
+    attr.value.s32 = SAI_TAM_REPORT_MODE_BULK;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_REPORT_ATTR_TEMPLATE_REPORT_INTERVAL;
+    // Don't push the template, Because we hope the template can be proactively queried by orchagent
+    attr.value.u32 = 0;
+    attrs.push_back(attr);
+
+    if (m_poll_interval != 0)
+    {
+        attr.id = SAI_TAM_REPORT_ATTR_REPORT_INTERVAL;
+        attr.value.u32 = m_poll_interval;
+        attrs.push_back(attr);
+    }
+
+    attr.id = SAI_TAM_REPORT_ATTR_REPORT_INTERVAL_UNIT;
+    attr.value.s32 = SAI_TAM_REPORT_INTERVAL_UNIT_USEC;
+
+    handleSaiCreateStatus(
+        SAI_API_TAM,
+        sai_tam_api->create_tam_report(
+            &sai_object,
+            gSwitchId,
+            static_cast<uint32_t>(attrs.size()),
+            attrs.data()));
+
+    m_sai_tam_report_objs[object_type] = move(
+        sai_guard_t(
+            new sai_object_id_t(sai_object),
+            [this](sai_object_id_t *p)
+            {
+                handleSaiRemoveStatus(
+                    SAI_API_TAM,
+                    sai_tam_api->remove_tam_report(*p));
+                delete p;
+            }));
+
+    return sai_object;
+}
+
+sai_object_id_t HFTelProfile::getTAMTelTypeObjID(sai_object_type_t object_type)
+{
+    SWSS_LOG_ENTER();
+
+    auto itr = m_sai_tam_tel_type_objs.find(object_type);
+    if (itr != m_sai_tam_tel_type_objs.end())
+    {
+        return *itr->second;
+    }
+
+    sai_object_id_t sai_object;
+    vector<sai_attribute_t> attrs;
+    sai_attribute_t attr;
+
+    // Create TAM telemetry type object
+
+    attr.id = SAI_TAM_TEL_TYPE_ATTR_TAM_TELEMETRY_TYPE;
+    attr.value.s32 = SAI_TAM_TELEMETRY_TYPE_COUNTER_SUBSCRIPTION;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_TEL_TYPE_ATTR_SWITCH_ENABLE_PORT_STATS;
+    attr.value.booldata = true;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_TEL_TYPE_ATTR_SWITCH_ENABLE_PORT_STATS_INGRESS;
+    attr.value.booldata = true;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_TEL_TYPE_ATTR_SWITCH_ENABLE_PORT_STATS_EGRESS;
+    attr.value.booldata = true;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_TEL_TYPE_ATTR_SWITCH_ENABLE_MMU_STATS;
+    attr.value.booldata = true;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_TEL_TYPE_ATTR_MODE ;
+    attr.value.s32 = SAI_TAM_TEL_TYPE_MODE_SINGLE_TYPE;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_TEL_TYPE_ATTR_REPORT_ID;
+    attr.value.oid = getTAMReportObjID(object_type);
+    attrs.push_back(attr);
+
+    handleSaiCreateStatus(
+        SAI_API_TAM,
+        sai_tam_api->create_tam_tel_type(
+            &sai_object,
+            gSwitchId,
+            static_cast<uint32_t>(attrs.size()),
+            attrs.data()));
+
+    m_sai_tam_tel_type_objs[object_type] = move(
+        sai_guard_t(
+            new sai_object_id_t(sai_object),
+            [this](sai_object_id_t *p)
+            {
+                HFTELUTILS_DEL_SAI_OBJECT_LIST(
+                    *this->m_sai_tam_telemetry_obj,
+                    SAI_TAM_TELEMETRY_ATTR_TAM_TYPE_LIST,
+                    *p,
+                    SAI_API_TAM,
+                    tam,
+                    tam_telemetry);
+
+                handleSaiRemoveStatus(
+                    SAI_API_TAM,
+                    sai_tam_api->remove_tam_tel_type(*p));
+                delete p;
+            }));
+    m_sai_tam_tel_type_states[m_sai_tam_tel_type_objs[object_type]] = SAI_TAM_TEL_TYPE_STATE_STOP_STREAM;
+
+    HFTELUTILS_ADD_SAI_OBJECT_LIST(
+        *m_sai_tam_telemetry_obj,
+        SAI_TAM_TELEMETRY_ATTR_TAM_TYPE_LIST,
+        sai_object,
+        SAI_API_TAM,
+        tam,
+        tam_telemetry);
+
+    return sai_object;
+}
+
+void HFTelProfile::initTelemetry()
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t sai_object;
+    vector<sai_attribute_t> attrs;
+    sai_attribute_t attr;
+    sai_object_id_t sai_tam_collector_obj = m_sai_tam_collector_obj;
+
+    // Create TAM telemetry object
+    attr.id = SAI_TAM_TELEMETRY_ATTR_COLLECTOR_LIST;
+    attr.value.objlist.count = 1;
+    attr.value.objlist.list = &sai_tam_collector_obj;
+    attrs.push_back(attr);
+
+    handleSaiCreateStatus(
+        SAI_API_TAM,
+        sai_tam_api->create_tam_telemetry(
+            &sai_object,
+            gSwitchId, static_cast<uint32_t>(attrs.size()),
+            attrs.data()));
+
+    HFTELUTILS_ADD_SAI_OBJECT_LIST(
+        m_sai_tam_obj,
+        SAI_TAM_ATTR_TELEMETRY_OBJECTS_LIST,
+        sai_object,
+        SAI_API_TAM,
+        tam,
+        tam);
+
+    m_sai_tam_telemetry_obj = move(
+        sai_guard_t(
+            new sai_object_id_t(sai_object),
+            [=](sai_object_id_t *p)
+            {
+                HFTELUTILS_DEL_SAI_OBJECT_LIST(
+                    m_sai_tam_obj,
+                    SAI_TAM_ATTR_TELEMETRY_OBJECTS_LIST,
+                    *p,
+                    SAI_API_TAM,
+                    tam,
+                    tam);
+
+                handleSaiRemoveStatus(
+                    SAI_API_TAM,
+                    sai_tam_api->remove_tam_telemetry(*p));
+                delete p;
+            }));
+}
+
+void HFTelProfile::deployCounterSubscription(sai_object_type_t object_type, sai_object_id_t sai_obj, sai_stat_id_t stat_id, uint16_t label)
+{
+    SWSS_LOG_ENTER();
+
+    vector<sai_attribute_t> attrs;
+    sai_attribute_t attr;
+
+    auto itr = m_sai_tam_counter_subscription_objs[object_type].find(sai_obj);
+    if (itr != m_sai_tam_counter_subscription_objs[object_type].end())
+    {
+        auto itr2 = itr->second.find(stat_id);
+        if (itr2 != itr->second.end())
+        {
+            return;
+        }
+    }
+
+    attr.id = SAI_TAM_COUNTER_SUBSCRIPTION_ATTR_TEL_TYPE;
+    attr.value.oid = getTAMTelTypeObjID(object_type);
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_COUNTER_SUBSCRIPTION_ATTR_OBJECT_ID;
+    attr.value.oid = sai_obj;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_COUNTER_SUBSCRIPTION_ATTR_STAT_ID;
+    attr.value.oid = stat_id;
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_COUNTER_SUBSCRIPTION_ATTR_LABEL;
+    attr.value.u64 = static_cast<uint64_t>(label);
+    attrs.push_back(attr);
+
+    attr.id = SAI_TAM_COUNTER_SUBSCRIPTION_ATTR_STATS_MODE;
+    attr.value.s32 = HFTelUtils::get_stats_mode(object_type, stat_id);
+    attrs.push_back(attr);
+
+    sai_object_id_t counter_id;
+
+    handleSaiCreateStatus(
+        SAI_API_TAM,
+        sai_tam_api->create_tam_counter_subscription(
+            &counter_id,
+            gSwitchId,
+            static_cast<uint32_t>(attrs.size()),
+            attrs.data()));
+
+    m_sai_tam_counter_subscription_objs[object_type][sai_obj][stat_id] = move(
+        sai_guard_t(
+            new sai_object_id_t(counter_id),
+            [](sai_object_id_t *p)
+            {
+                handleSaiRemoveStatus(
+                    SAI_API_TAM,
+                    sai_tam_api->remove_tam_counter_subscription(*p));
+                delete p;
+            }));
+}
+
+void HFTelProfile::deployCounterSubscriptions(sai_object_type_t object_type, sai_object_id_t sai_obj, std::uint16_t label)
+{
+    SWSS_LOG_ENTER();
+
+    // TODO: Bulk create the counter subscriptions
+    auto group = m_groups.find(object_type);
+    if (group == m_groups.end())
+    {
+        return;
+    }
+
+    for (const auto &stat_id : group->second.getStatsIDs())
+    {
+        deployCounterSubscription(object_type, sai_obj, stat_id, label);
+    }
+}
+
+void HFTelProfile::deployCounterSubscriptions(sai_object_type_t object_type)
+{
+    SWSS_LOG_ENTER();
+
+    // TODO: Bulk create the counter subscriptions
+
+    auto group = m_groups.find(object_type);
+    if (group == m_groups.end())
+    {
+        return;
+    }
+    for (const auto &obj : group->second.getObjects())
+    {
+        auto itr = m_name_sai_map[object_type].find(obj.first);
+        if (itr == m_name_sai_map[object_type].end())
+        {
+            continue;
+        }
+        for (const auto &stat_id : group->second.getStatsIDs())
+        {
+            deployCounterSubscription(object_type, itr->second, stat_id, obj.second);
+        }
+    }
+}
+
+void HFTelProfile::undeployCounterSubscriptions(sai_object_type_t object_type)
+{
+    SWSS_LOG_ENTER();
+
+    // TODO: Bulk remove the counter subscriptions
+    m_sai_tam_counter_subscription_objs.erase(object_type);
+}
+
+void HFTelProfile::updateTemplates(sai_object_id_t tam_tel_type_obj)
+{
+    SWSS_LOG_ENTER();
+
+    auto object_type = getObjectType(tam_tel_type_obj);
+    if (object_type == SAI_OBJECT_TYPE_NULL)
+    {
+        SWSS_LOG_THROW("The object type is not found");
+    }
+
+    // Estimate the template size
+    auto counters = m_sai_tam_counter_subscription_objs.find(object_type);
+    if (counters == m_sai_tam_counter_subscription_objs.end())
+    {
+        SWSS_LOG_THROW("The counter subscription object is not found");
+    }
+    size_t counters_count = 0;
+    for (const auto &item : counters->second)
+    {
+        counters_count += item.second.size();
+    }
+
+    const size_t COUNTER_SIZE (8LLU);
+    const size_t IPFIX_TEMPLATE_MAX_SIZE (0xffffLLU);
+    const size_t IPFIX_HEADER_SIZE (16LLU);
+    const size_t IPFIX_TEMPLATE_METADATA_SIZE (12LLU);
+    const size_t IPFIX_TEMPLATE_MAX_STATS_COUNT (((IPFIX_TEMPLATE_MAX_SIZE - IPFIX_HEADER_SIZE - IPFIX_TEMPLATE_METADATA_SIZE) / COUNTER_SIZE) - 1LLU);
+    size_t estimated_template_size = (counters_count / IPFIX_TEMPLATE_MAX_STATS_COUNT + 1) * IPFIX_TEMPLATE_MAX_SIZE;
+
+    vector<uint8_t> buffer(estimated_template_size, 0);
+
+    sai_attribute_t attr;
+    attr.id = SAI_TAM_TEL_TYPE_ATTR_IPFIX_TEMPLATES;
+    attr.value.u8list.count = static_cast<uint32_t>(buffer.size());
+    attr.value.u8list.list = buffer.data();
+
+    auto status = sai_tam_api->get_tam_tel_type_attribute(tam_tel_type_obj, 1, &attr);
+    if (status == SAI_STATUS_BUFFER_OVERFLOW)
+    {
+        buffer.resize(attr.value.u8list.count);
+        attr.value.u8list.list = buffer.data();
+        status = sai_tam_api->get_tam_tel_type_attribute(tam_tel_type_obj, 1, &attr);
+    }
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_THROW("Failed to get the TAM telemetry type object %s attributes: %d",
+                       sai_serialize_object_id(tam_tel_type_obj).c_str(), status);
+    }
+
+    buffer.resize(attr.value.u8list.count);
+
+    m_sai_tam_tel_type_templates[object_type] = move(buffer);
+}

--- a/orchagent/high_frequency_telemetry/hftelprofile.h
+++ b/orchagent/high_frequency_telemetry/hftelprofile.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <saitypes.h>
+#include <saitam.h>
+#include <swss/table.h>
+
+#include <string>
+#include <cstdint>
+#include <map>
+#include <unordered_map>
+#include <vector>
+#include <set>
+#include <string>
+#include <memory>
+
+#include "hftelgroup.h"
+
+
+using CounterNameCache = std::unordered_map<sai_object_type_t, std::unordered_map<std::string, sai_object_id_t>>;
+
+class HFTelProfile
+{
+public:
+    HFTelProfile(
+        const std::string &profile_name,
+        sai_object_id_t sai_tam_obj,
+        sai_object_id_t sai_tam_collector_obj,
+        const CounterNameCache &cache);
+    ~HFTelProfile();
+    HFTelProfile(const HFTelProfile &) = delete;
+    HFTelProfile &operator=(const HFTelProfile &) = delete;
+    HFTelProfile(HFTelProfile &&) = delete;
+    HFTelProfile &operator=(HFTelProfile &&) = delete;
+
+    using sai_guard_t = std::shared_ptr<sai_object_id_t>;
+
+    const std::string& getProfileName() const;
+    void setStreamState(sai_tam_tel_type_state_t state);
+    void setStreamState(sai_object_type_t object_type, sai_tam_tel_type_state_t state);
+    sai_tam_tel_type_state_t getStreamState(sai_object_type_t object_type) const;
+    void notifyConfigReady(sai_object_type_t object_type);
+    sai_tam_tel_type_state_t getTelemetryTypeState(sai_object_type_t object_type) const;
+    sai_guard_t getTAMTelTypeGuard(sai_object_id_t tam_tel_type_obj) const;
+    sai_object_type_t getObjectType(sai_object_id_t tam_tel_type_obj) const;
+    void setPollInterval(std::uint32_t poll_interval);
+    void setBulkSize(std::uint32_t bulk_size);
+    void setObjectNames(const std::string &group_name, std::set<std::string> &&object_names);
+    void setStatsIDs(const std::string &group_name, const std::set<std::string> &object_counters);
+    void setObjectSAIID(sai_object_type_t object_type, const char *object_name, sai_object_id_t object_id);
+    void delObjectSAIID(sai_object_type_t object_type, const char *object_name);
+    bool canBeUpdated() const;
+    bool canBeUpdated(sai_object_type_t object_type) const;
+    bool isEmpty() const;
+    void clearGroup(const std::string &group_name);
+
+    const std::vector<std::uint8_t> &getTemplates(sai_object_type_t object_type) const;
+    const std::vector<std::string> getObjectNames(sai_object_type_t object_type) const;
+    const std::vector<std::uint16_t> getObjectLabels(sai_object_type_t object_type) const;
+    std::pair<std::vector<std::string>, std::vector<std::string>> getObjectNamesAndLabels(sai_object_type_t object_type) const;
+    std::vector<sai_object_type_t> getObjectTypes() const;
+
+    void loadCounterNameCache(sai_object_type_t object_type);
+    bool tryCommitConfig(sai_object_type_t object_type);
+
+private:
+    // Configuration parameters
+    const std::string m_profile_name;
+    sai_tam_tel_type_state_t m_setting_state;
+    std::uint32_t m_poll_interval;
+    std::map<sai_object_type_t, HFTelGroup> m_groups;
+
+    // Runtime parameters
+    const CounterNameCache &m_counter_name_cache;
+
+    std::unordered_map<
+        sai_object_type_t,
+        std::unordered_map<
+            std::string,
+            sai_object_id_t>>
+        m_name_sai_map;
+
+    // SAI objects
+    const sai_object_id_t m_sai_tam_obj;
+    const sai_object_id_t m_sai_tam_collector_obj;
+    std::unordered_map<
+        sai_object_type_t,
+        std::unordered_map<
+            sai_object_id_t,
+            std::unordered_map<
+                sai_stat_id_t,
+                sai_guard_t>>>
+        m_sai_tam_counter_subscription_objs;
+    sai_guard_t m_sai_tam_telemetry_obj;
+    std::unordered_map<sai_guard_t, sai_tam_tel_type_state_t> m_sai_tam_tel_type_states;
+    std::unordered_map<sai_object_type_t, sai_guard_t> m_sai_tam_tel_type_objs;
+    std::unordered_map<sai_object_type_t, sai_guard_t> m_sai_tam_report_objs;
+    std::unordered_map<sai_object_type_t, std::vector<std::uint8_t>> m_sai_tam_tel_type_templates;
+
+    bool isObjectTypeInProfile(sai_object_type_t object_type, const std::string &object_name) const;
+    bool isMonitoringObjectReady(sai_object_type_t object_type) const;
+
+    // SAI calls
+    sai_object_id_t getTAMReportObjID(sai_object_type_t object_type);
+    sai_object_id_t getTAMTelTypeObjID(sai_object_type_t object_type);
+    void initTelemetry();
+    void deployCounterSubscription(sai_object_type_t object_type, sai_object_id_t sai_obj, sai_stat_id_t stat_id, std::uint16_t label);
+    void deployCounterSubscriptions(sai_object_type_t object_type, sai_object_id_t sai_obj, std::uint16_t label);
+    void deployCounterSubscriptions(sai_object_type_t object_type);
+    void undeployCounterSubscriptions(sai_object_type_t object_type);
+    void updateTemplates(sai_object_id_t tam_tel_type_obj);
+};

--- a/orchagent/high_frequency_telemetry/hftelutils.cpp
+++ b/orchagent/high_frequency_telemetry/hftelutils.cpp
@@ -1,0 +1,139 @@
+#include "hftelutils.h"
+
+#include <saihelper.h>
+#include <swss/logger.h>
+
+#include <boost/algorithm/string.hpp>
+#include <regex>
+
+using namespace std;
+
+#define OBJECT_TYPE_PREFIX "SAI_OBJECT_TYPE_"
+
+vector<sai_object_id_t> HFTelUtils::get_sai_object_list(
+    sai_object_id_t obj,
+    sai_attr_id_t attr_id,
+    sai_api_t api,
+    function<sai_status_t(sai_object_id_t, uint32_t, sai_attribute_t*)> get_attribute_handler)
+{
+    SWSS_LOG_ENTER();
+
+    vector<sai_object_id_t> obj_list(1024, SAI_NULL_OBJECT_ID);
+    sai_attribute_t attr;
+
+    attr.id = attr_id;
+    attr.value.objlist.count = static_cast<uint32_t>(obj_list.size());
+    attr.value.objlist.list = obj_list.data();
+
+    auto status = get_attribute_handler(
+        obj,
+        1,
+        &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        handleSaiGetStatus(
+            api,
+            status);
+    }
+    assert(attr.value.objlist.count < obj_list.size());
+
+    obj_list.erase(
+        obj_list.begin() + attr.value.objlist.count,
+        obj_list.end());
+
+    return obj_list;
+}
+
+sai_object_type_t HFTelUtils::group_name_to_sai_type(const string &group_name)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_type_t sai_object_type;
+
+    sai_deserialize_object_type(string(OBJECT_TYPE_PREFIX) + boost::to_upper_copy(group_name), sai_object_type);
+    return sai_object_type;
+}
+
+std::string HFTelUtils::sai_type_to_group_name(sai_object_type_t object_type)
+{
+    SWSS_LOG_ENTER();
+
+    std::string group_name = sai_serialize_object_type(object_type);
+
+    group_name.erase(0, sizeof(OBJECT_TYPE_PREFIX) - 1);
+
+    return group_name;
+}
+
+set<sai_stat_id_t> HFTelUtils::object_counters_to_stats_ids(
+    const string &group_name,
+    const set<string> &object_counters)
+{
+    SWSS_LOG_ENTER();
+    sai_object_type_t sai_object_type = HFTelUtils::group_name_to_sai_type(group_name);
+    set<sai_stat_id_t> stats_ids_set;
+
+    auto info = sai_metadata_get_object_type_info(sai_object_type);
+    if (info == nullptr)
+    {
+        SWSS_LOG_THROW("Failed to get the object type info for %s", group_name.c_str());
+    }
+
+    auto state_enum = info->statenum;
+    if (state_enum == nullptr)
+    {
+        SWSS_LOG_THROW("The object type %s does not support stats", group_name.c_str());
+    }
+
+    string type_prefix = "SAI_" + group_name + "_STAT_";
+
+    for (size_t i = 0; i < state_enum->valuescount; i++)
+    {
+        if (object_counters.find(state_enum->valuesshortnames[i]) != object_counters.end())
+        {
+            SWSS_LOG_DEBUG("Found the object counter %s", state_enum->valuesshortnames[i]);
+            stats_ids_set.insert(state_enum->values[i]);
+        }
+    }
+
+    if (stats_ids_set.size() != object_counters.size())
+    {
+        SWSS_LOG_THROW("Failed to convert the object counters to stats ids for %s", group_name.c_str());
+    }
+
+    return stats_ids_set;
+}
+
+sai_stats_mode_t HFTelUtils::get_stats_mode(sai_object_type_t object_type, sai_stat_id_t stat_id)
+{
+    SWSS_LOG_ENTER();
+
+    switch(object_type)
+    {
+        case SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP:
+            switch(stat_id)
+            {
+                case SAI_INGRESS_PRIORITY_GROUP_STAT_WATERMARK_BYTES:
+                case SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_WATERMARK_BYTES:
+                case SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES:
+                    return SAI_STATS_MODE_READ_AND_CLEAR;
+                default:
+                    break;
+            }
+            break;
+        case SAI_OBJECT_TYPE_BUFFER_POOL:
+            switch(stat_id)
+            {
+                case SAI_BUFFER_POOL_STAT_WATERMARK_BYTES:
+                case SAI_BUFFER_POOL_STAT_XOFF_ROOM_WATERMARK_BYTES:
+                    return SAI_STATS_MODE_READ_AND_CLEAR;
+                default:
+                    break;
+            }
+            break;
+        default:
+            break;
+    }
+
+    return SAI_STATS_MODE_READ;
+}

--- a/orchagent/high_frequency_telemetry/hftelutils.h
+++ b/orchagent/high_frequency_telemetry/hftelutils.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <sai.h>
+#include <saitypes.h>
+
+#include <set>
+#include <string>
+#include <vector>
+#include <functional>
+#include <cstdint>
+
+class HFTelUtils
+{
+public:
+    HFTelUtils() = delete;
+
+    static std::vector<sai_object_id_t> get_sai_object_list(
+        sai_object_id_t obj,
+        sai_attr_id_t attr_id,
+        sai_api_t api,
+        std::function<sai_status_t(sai_object_id_t, uint32_t, sai_attribute_t*)> get_attribute_handler);
+    static sai_object_type_t group_name_to_sai_type(const std::string &group_name);
+    static std::string sai_type_to_group_name(sai_object_type_t object_type);
+    static std::set<sai_stat_id_t> object_counters_to_stats_ids(
+        const std::string &group_name,
+        const std::set<std::string> &object_counters);
+    static sai_stats_mode_t get_stats_mode(sai_object_type_t object_type, sai_stat_id_t stat_id);
+};
+
+#define HFTELUTILS_ADD_SAI_OBJECT_LIST(obj, attr_id, inserted_obj, api_type_name, api_name, obj_type_name) \
+    {                                                                                                      \
+        sai_attribute_t attr;                                                                              \
+        auto obj_list = HFTelUtils::get_sai_object_list(                                                   \
+            obj,                                                                                           \
+            attr_id,                                                                                       \
+            api_type_name,                                                                                 \
+            sai_##api_name##_api->get_##obj_type_name##_attribute);                                        \
+        obj_list.push_back(inserted_obj);                                                                  \
+        attr.id = attr_id;                                                                                 \
+        attr.value.objlist.count = static_cast<uint32_t>(obj_list.size());                                 \
+        attr.value.objlist.list = obj_list.data();                                                         \
+        sai_status_t status = sai_##api_name##_api->set_##obj_type_name##_attribute(                       \
+            obj,                                                                                           \
+            &attr);                                                                                        \
+        if (status != SAI_STATUS_SUCCESS)                                                                  \
+        {                                                                                                  \
+            handleSaiSetStatus(                                                                            \
+                api_type_name,                                                                             \
+                status);                                                                                   \
+        }                                                                                                  \
+    }
+
+#define HFTELUTILS_DEL_SAI_OBJECT_LIST(obj, attr_id, removed_obj, api_type_name, api_name, obj_type_name) \
+    {                                                                                                     \
+        sai_attribute_t attr;                                                                             \
+        auto obj_list = HFTelUtils::get_sai_object_list(                                                  \
+            obj,                                                                                          \
+            attr_id,                                                                                      \
+            api_type_name,                                                                                \
+            sai_##api_name##_api->get_##obj_type_name##_attribute);                                       \
+        obj_list.erase(                                                                                   \
+            std::remove(                                                                                  \
+                obj_list.begin(),                                                                         \
+                obj_list.end(),                                                                           \
+                removed_obj),                                                                             \
+            obj_list.end());                                                                              \
+        attr.id = attr_id;                                                                                \
+        attr.value.objlist.count = static_cast<uint32_t>(obj_list.size());                                \
+        attr.value.objlist.list = obj_list.data();                                                        \
+        sai_status_t status = sai_##api_name##_api->set_##obj_type_name##_attribute(                      \
+            obj,                                                                                          \
+            &attr);                                                                                       \
+        if (status != SAI_STATUS_SUCCESS)                                                                 \
+        {                                                                                                 \
+            handleSaiSetStatus(                                                                           \
+                api_type_name,                                                                            \
+                status);                                                                                  \
+        }                                                                                                 \
+    }

--- a/orchagent/notifications.cpp
+++ b/orchagent/notifications.cpp
@@ -83,3 +83,7 @@ void on_switch_asic_sdk_health_event(sai_object_id_t switch_id,
                                             data,
                                             description);
 }
+
+void on_tam_tel_type_config_change(sai_object_id_t tam_tel_id)
+{
+}

--- a/orchagent/notifications.h
+++ b/orchagent/notifications.h
@@ -21,3 +21,5 @@ void on_switch_asic_sdk_health_event(sai_object_id_t switch_id,
                                      sai_switch_asic_sdk_health_category_t category,
                                      sai_switch_health_data_t data,
                                      const sai_u8_list_t description);
+
+void on_tam_tel_type_config_change(sai_object_id_t tam_tel_id);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -65,6 +65,7 @@ DebugCounterOrch *gDebugCounterOrch;
 MonitorOrch *gMonitorOrch;
 TunnelDecapOrch *gTunneldecapOrch;
 MuxOrch *gMuxOrch;
+HFTelOrch *gHFTOrch;
 
 bool gIsNatSupported = false;
 event_handle_t g_events_handle;
@@ -780,6 +781,21 @@ bool OrchDaemon::init()
     TableConnector stateDbTwampTable(m_stateDb, STATE_TWAMP_SESSION_TABLE_NAME);
     TwampOrch *twamp_orch = new TwampOrch(confDbTwampTable, stateDbTwampTable, gSwitchOrch, gPortsOrch, vrf_orch);
     m_orchList.push_back(twamp_orch);
+
+    if (HFTelOrch::isSupportedHFTel(gSwitchId))
+    {
+        const vector<string> stel_tables = {
+            CFG_HIGH_FREQUENCY_TELEMETRY_PROFILE_TABLE_NAME,
+            CFG_HIGH_FREQUENCY_TELEMETRY_GROUP_TABLE_NAME
+        };
+        gHFTOrch = new HFTelOrch(m_configDb, m_stateDb, stel_tables);
+        m_orchList.push_back(gHFTOrch);
+        SWSS_LOG_NOTICE("High Frequency Telemetry is supported on this platform");
+    }
+    else
+    {
+        SWSS_LOG_NOTICE("High Frequency Telemetry is not supported on this platform");
+    }
 
     if (WarmStart::isWarmStart())
     {

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -51,6 +51,7 @@
 #include "dash/dashorch.h"
 #include "dash/dashrouteorch.h"
 #include "dash/dashvnetorch.h"
+#include "high_frequency_telemetry/hftelorch.h"
 #include <sairedis.h>
 
 using namespace swss;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -585,7 +585,8 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
 
     /* Initialize counter table */
     m_counter_db = shared_ptr<DBConnector>(new DBConnector("COUNTERS_DB", 0));
-    m_counterTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_PORT_NAME_MAP));
+    // m_counterTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_PORT_NAME_MAP));
+    m_counterNameMapUpdater = unique_ptr<CounterNameMapUpdater>(new CounterNameMapUpdater("COUNTERS_DB", COUNTERS_PORT_NAME_MAP));
     m_counterSysPortTable = unique_ptr<Table>(
                     new Table(m_counter_db.get(), COUNTERS_SYSTEM_PORT_NAME_MAP));
     m_counterLagTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_LAG_NAME_MAP));
@@ -3736,7 +3737,8 @@ bool PortsOrch::initPort(const PortConfig &port)
                 FieldValueTuple tuple(p.m_alias, sai_serialize_object_id(p.m_port_id));
                 vector<FieldValueTuple> fields;
                 fields.push_back(tuple);
-                m_counterTable->set("", fields);
+                // m_counterTable->set("", fields);
+                m_counterNameMapUpdater->setCounterNameMap(p.m_alias, p.m_port_id);
 
                 // Install a flex counter for this port to track stats
                 auto flex_counters_orch = gDirectory.get<FlexCounterOrch*>();
@@ -3835,7 +3837,8 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     }
 
     /* remove port name map from counter table */
-    m_counterTable->hdel("", alias);
+    // m_counterTable->hdel("", alias);
+    m_counterNameMapUpdater->delCounterNameMap(alias);
 
     /* Remove the associated port serdes attribute */
     removePortSerdesAttribute(p.m_port_id);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -21,6 +21,8 @@
 #include "port/porthlpr.h"
 #include "port/portschema.h"
 
+#include "high_frequency_telemetry/counternameupdater.h"
+
 #define FCS_LEN 4
 #define VLAN_TAG_LEN 4
 #define MAX_MACSEC_SECTAG_SIZE 32
@@ -257,7 +259,8 @@ public:
     bool setPortPtTimestampTemplate(const Port& port, sai_port_path_tracing_timestamp_type_t ts_type);
 
 private:
-    unique_ptr<Table> m_counterTable;
+    unique_ptr<CounterNameMapUpdater> m_counterNameMapUpdater;
+    // unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterSysPortTable;
     unique_ptr<Table> m_counterLagTable;
     unique_ptr<Table> m_portTable;

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -142,7 +142,13 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/warmrestart/warmRestartAssist.cpp \
                 $(top_srcdir)/orchagent/dash/pbutils.cpp \
                 $(top_srcdir)/cfgmgr/coppmgr.cpp \
-                $(top_srcdir)/orchagent/twamporch.cpp
+                $(top_srcdir)/orchagent/twamporch.cpp \
+                $(top_srcdir)/orchagent/high_frequency_telemetry/hftelorch.cpp \
+                $(top_srcdir)/orchagent/high_frequency_telemetry/hftelprofile.cpp \
+                $(top_srcdir)/orchagent/high_frequency_telemetry/counternameupdater.cpp \
+                $(top_srcdir)/orchagent/high_frequency_telemetry/hftelutils.cpp \
+                $(top_srcdir)/orchagent/high_frequency_telemetry/hftelgroup.cpp
+
 
 tests_SOURCES += $(FLEX_CTR_DIR)/flex_counter_manager.cpp $(FLEX_CTR_DIR)/flex_counter_stat_manager.cpp $(FLEX_CTR_DIR)/flow_counter_handler.cpp $(FLEX_CTR_DIR)/flowcounterrouteorch.cpp
 tests_SOURCES += $(DEBUG_CTR_DIR)/debug_counter.cpp $(DEBUG_CTR_DIR)/drop_counter.cpp

--- a/tests/test_hft.py
+++ b/tests/test_hft.py
@@ -1,0 +1,407 @@
+import time
+
+from swsscommon import swsscommon
+
+
+class TestHFT(object):
+    """Test High Frequency Telemetry (HFT) functionality using DVS."""
+
+    def setup_method(self, method):
+        """Set up test method with database connections."""
+        pass
+
+    def teardown_method(self, method):
+        """Clean up after each test method."""
+        pass
+
+    def create_hft_profile(self, dvs, name="test", status="enabled",
+                           polling_interval=300):
+        """Create HFT profile in CONFIG_DB."""
+        config_db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        tbl = swsscommon.Table(config_db, "HIGH_FREQUENCY_TELEMETRY_PROFILE")
+
+        fvs = swsscommon.FieldValuePairs([
+            ("stream_state", status),
+            ("poll_interval", str(polling_interval))
+        ])
+        tbl.set(name, fvs)
+
+    def create_hft_group(self, dvs, profile_name="test", group_name="PORT",
+                         object_names="Ethernet0",
+                         object_counters="IF_IN_OCTETS"):
+        """Create HFT group in CONFIG_DB."""
+        config_db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        tbl = swsscommon.Table(config_db, "HIGH_FREQUENCY_TELEMETRY_GROUP")
+
+        key = f"{profile_name}|{group_name}"
+        fvs = swsscommon.FieldValuePairs([
+            ("object_names", object_names),
+            ("object_counters", object_counters)
+        ])
+        tbl.set(key, fvs)
+
+    def delete_hft_profile(self, dvs, name="test"):
+        """Delete HFT profile from CONFIG_DB."""
+        config_db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        tbl = swsscommon.Table(config_db, "HIGH_FREQUENCY_TELEMETRY_PROFILE")
+        tbl._del(name)
+
+    def delete_hft_group(self, dvs, profile_name="test", group_name="PORT"):
+        """Delete HFT group from CONFIG_DB."""
+        config_db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        tbl = swsscommon.Table(config_db, "HIGH_FREQUENCY_TELEMETRY_GROUP")
+        key = f"{profile_name}|{group_name}"
+        tbl._del(key)
+
+    def get_asic_db_objects(self, dvs):
+        """Get all relevant HFT-related objects from ASIC_STATE DB."""
+        asic_db = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+
+        # Get all TAM-related objects
+        tam_transport_tbl = swsscommon.Table(
+            asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_TAM_TRANSPORT")
+        tam_collector_tbl = swsscommon.Table(
+            asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_TAM_COLLECTOR")
+        tam_tel_type_tbl = swsscommon.Table(
+            asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_TAM_TEL_TYPE")
+        tam_report_tbl = swsscommon.Table(
+            asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_TAM_REPORT")
+        tam_tbl = swsscommon.Table(asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_TAM")
+        tam_counter_sub_tbl = swsscommon.Table(
+            asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_TAM_COUNTER_SUBSCRIPTION")
+        tam_telemetry_tbl = swsscommon.Table(
+            asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_TAM_TELEMETRY")
+        hostif_trap_tbl = swsscommon.Table(
+            asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP")
+        host_trap_group_tbl = swsscommon.Table(
+            asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF_TRAP_GROUP")
+        ports_tbl = swsscommon.Table(
+            asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
+
+        return {
+            "tam_transport": self._get_table_entries(tam_transport_tbl),
+            "tam_collector": self._get_table_entries(tam_collector_tbl),
+            "tam_tel_type": self._get_table_entries(tam_tel_type_tbl),
+            "tam_report": self._get_table_entries(tam_report_tbl),
+            "tam": self._get_table_entries(tam_tbl),
+            "tam_counter_subscription": self._get_table_entries(
+                tam_counter_sub_tbl),
+            "tam_telemetry": self._get_table_entries(tam_telemetry_tbl),
+            "hostif_user_defined_trap": self._get_table_entries(
+                hostif_trap_tbl),
+            "host_trap_group": self._get_table_entries(host_trap_group_tbl),
+            "ports": self._get_table_entries(ports_tbl)
+        }
+
+    def _get_table_entries(self, table):
+        """Helper method to get all entries from a table."""
+        entries = {}
+        keys = table.getKeys()
+        for key in keys:
+            status, fvs = table.get(key)
+            if status:
+                entries[key] = dict(fvs)
+        return entries
+
+    def verify_asic_db_objects(self, asic_db, groups=[(1, 1)]):
+        """Verify HFT objects are created correctly in ASIC_STATE DB."""
+
+        # If no groups, we expect minimal or no HFT objects
+        if not groups:
+            # When no groups are configured, counter subscriptions should be
+            # empty
+            assert len(asic_db["tam_counter_subscription"]) == 0, \
+                "Expected no tam counter subscriptions when no groups " \
+                "configured"
+            # Other objects might still exist as base infrastructure
+            return
+
+        # Verify TAM transport
+        assert len(asic_db["tam_transport"]) == 1, "Expected one tam transport"
+        tam_transport = list(asic_db["tam_transport"].values())[0]
+        assert tam_transport["SAI_TAM_TRANSPORT_ATTR_TRANSPORT_TYPE"] == \
+            "SAI_TAM_TRANSPORT_TYPE_NONE", \
+            "Expected tam transport type to be SAI_TAM_TRANSPORT_TYPE_NONE"
+
+        # Verify TAM collector
+        assert len(asic_db["tam_collector"]) == 1, "Expected one tam collector"
+        tam_collector = list(asic_db["tam_collector"].values())[0]
+
+        # Fix: Use only the object ID, not the full key
+        transport_oid = tam_collector["SAI_TAM_COLLECTOR_ATTR_TRANSPORT"]
+        assert transport_oid in asic_db["tam_transport"], \
+            f"Expected tam collector to reference tam transport. " \
+            f"Looking for {transport_oid} in " \
+            f"{list(asic_db['tam_transport'].keys())}"
+
+        assert tam_collector["SAI_TAM_COLLECTOR_ATTR_LOCALHOST"] == "true", \
+            "Expected tam collector to be localhost"
+
+        # Fix: Use only the object ID
+        trap_oid = tam_collector["SAI_TAM_COLLECTOR_ATTR_HOSTIF_TRAP"]
+        assert trap_oid in asic_db["hostif_user_defined_trap"], \
+            "Expected tam collector to reference hostif user defined trap"
+
+        # Verify TAM telemetry type
+        assert len(asic_db["tam_tel_type"]) == len(groups), \
+            f"Expected {len(groups)} tam telemetry types"
+
+        for tam_tel_type in asic_db["tam_tel_type"].values():
+            assert tam_tel_type[
+                "SAI_TAM_TEL_TYPE_ATTR_TAM_TELEMETRY_TYPE"] == \
+                "SAI_TAM_TELEMETRY_TYPE_COUNTER_SUBSCRIPTION", \
+                "Expected tam telemetry type to be " \
+                "SAI_TAM_TELEMETRY_TYPE_COUNTER_SUBSCRIPTION"
+            assert tam_tel_type[
+                "SAI_TAM_TEL_TYPE_ATTR_SWITCH_ENABLE_PORT_STATS"] == \
+                "true", \
+                "Expected tam telemetry to be switch enable port stats"
+            assert tam_tel_type["SAI_TAM_TEL_TYPE_ATTR_MODE"] == \
+                "SAI_TAM_TEL_TYPE_MODE_SINGLE_TYPE", \
+                "Expected tam telemetry to be mode single type"
+
+            # Fix: Use only the object ID
+            report_oid = tam_tel_type["SAI_TAM_TEL_TYPE_ATTR_REPORT_ID"]
+            assert report_oid in asic_db["tam_report"], \
+                "Expected tam telemetry to reference tam report"
+
+        # Verify TAM report
+        assert len(asic_db["tam_report"]) == len(groups), \
+            f"Expected {len(groups)} tam reports"
+
+        for tam_report in asic_db["tam_report"].values():
+            assert tam_report["SAI_TAM_REPORT_ATTR_TYPE"] == \
+                "SAI_TAM_REPORT_TYPE_IPFIX", \
+                "Expected tam report type to be SAI_TAM_REPORT_TYPE_IPFIX"
+            assert tam_report["SAI_TAM_REPORT_ATTR_REPORT_MODE"] == \
+                "SAI_TAM_REPORT_MODE_BULK", \
+                "Expected tam report mode to be SAI_TAM_REPORT_MODE_BULK"
+            assert tam_report[
+                "SAI_TAM_REPORT_ATTR_TEMPLATE_REPORT_INTERVAL"] == \
+                "0", \
+                "Expected tam report template report interval to be 0"
+            assert tam_report["SAI_TAM_REPORT_ATTR_REPORT_INTERVAL"] == \
+                "300", \
+                "Expected tam report report interval to be 300"
+
+        # Verify main TAM object
+        assert len(asic_db["tam"]) == 1, "Expected one tam object"
+        tam = list(asic_db["tam"].values())[0]
+        assert "SAI_TAM_BIND_POINT_TYPE_SWITCH" in \
+            tam["SAI_TAM_ATTR_TAM_BIND_POINT_TYPE_LIST"], \
+            "Expected tam to have bind point type list"
+
+        # Fix: Extract the telemetry object ID and check directly
+        tam_telemetry_oid = ":".join(
+            tam["SAI_TAM_ATTR_TELEMETRY_OBJECTS_LIST"].split(":")[1:3])
+        assert tam_telemetry_oid in asic_db["tam_telemetry"], \
+            "Expected tam to reference tam telemetry"
+
+        # Verify TAM counter subscriptions
+        counters_number = sum([group[0] * group[1] for group in groups])
+        assert len(asic_db["tam_counter_subscription"]) == counters_number, \
+            f"Expected {counters_number} tam counter subscriptions"
+
+        for tam_counter_sub in asic_db["tam_counter_subscription"].values():
+            # Fix: Use only the object ID
+            tel_type_oid = tam_counter_sub[
+                "SAI_TAM_COUNTER_SUBSCRIPTION_ATTR_TEL_TYPE"]
+            assert tel_type_oid in asic_db["tam_tel_type"], \
+                "Expected tam counter subscription to reference tam " \
+                "telemetry type"
+
+            # Fix: Use only the object ID
+            port_oid = tam_counter_sub[
+                "SAI_TAM_COUNTER_SUBSCRIPTION_ATTR_OBJECT_ID"]
+            assert port_oid in asic_db["ports"], \
+                "Expected tam counter subscription to reference port"
+
+            # Only check if we have counter subscriptions
+            if counters_number > 0:
+                assert tam_counter_sub[
+                    "SAI_TAM_COUNTER_SUBSCRIPTION_ATTR_STATS_MODE"] == \
+                    "SAI_STATS_MODE_READ", \
+                    "Expected tam counter subscription stats mode to be " \
+                    "SAI_STATS_MODE_READ"
+
+        # Verify TAM telemetry
+        assert len(asic_db["tam_telemetry"]) == 1, "Expected one tam telemetry"
+        tam_telemetry = list(asic_db["tam_telemetry"].values())[0]
+
+        collector_list_count = tam_telemetry[
+            "SAI_TAM_TELEMETRY_ATTR_COLLECTOR_LIST"].split(":")[0]
+        assert collector_list_count == "1", \
+            "Expected tam telemetry collector list count to be 1"
+
+        # Fix: Extract the collector object ID and check directly
+        collector_oid = ":".join(tam_telemetry[
+            "SAI_TAM_TELEMETRY_ATTR_COLLECTOR_LIST"].split(":")[1:3])
+        assert collector_oid in asic_db["tam_collector"], \
+            "Expected tam telemetry to reference tam collector"
+
+        tam_type_list_count = tam_telemetry[
+            "SAI_TAM_TELEMETRY_ATTR_TAM_TYPE_LIST"].split(":")[0]
+        assert tam_type_list_count == str(len(groups)), \
+            f"Expected tam telemetry tam type list count to be {len(groups)}"
+
+        if len(groups) == 1:
+            # Fix: Extract the telemetry type object ID and check directly
+            tam_type_oid = ":".join(tam_telemetry[
+                "SAI_TAM_TELEMETRY_ATTR_TAM_TYPE_LIST"].split(":")[1:3])
+            assert tam_type_oid in asic_db["tam_tel_type"], \
+                "Expected tam telemetry to reference tam telemetry type"
+
+        # Verify hostif user defined trap
+        assert len(asic_db["hostif_user_defined_trap"]) == 1, \
+            "Expected one hostif user defined trap"
+        hostif_trap = list(asic_db["hostif_user_defined_trap"].values())[0]
+        assert hostif_trap["SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_TYPE"] == \
+            "SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_TAM", \
+            "Expected hostif user defined trap type to be " \
+            "SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_TAM"
+
+    def verify_no_asic_objects(self, asic_db):
+        """Verify that HFT objects are cleaned up from ASIC_STATE DB."""
+        # We expect some objects to remain (like base infrastructure)
+        # but counter subscriptions should be cleaned up
+        pass
+
+    def test_simple_hft_one_counter(self, dvs, testlog):
+        """Test basic HFT functionality with one counter."""
+        # Create HFT profile and group
+        self.create_hft_profile(dvs)
+        self.create_hft_group(dvs)
+
+        # Wait for objects to be created
+        time.sleep(5)
+
+        # Verify ASIC objects are created
+        asic_db = self.get_asic_db_objects(dvs)
+        self.verify_asic_db_objects(asic_db, groups=[(1, 1)])
+
+        # Clean up group first
+        self.delete_hft_group(dvs)
+        time.sleep(2)
+
+        # Verify counter subscriptions are cleaned up
+        asic_db = self.get_asic_db_objects(dvs)
+        self.verify_asic_db_objects(asic_db, groups=[])
+
+        # Clean up profile
+        self.delete_hft_profile(dvs)
+
+    def test_hft_multiple_counters(self, dvs, testlog):
+        """Test HFT functionality with multiple counters and objects."""
+        # Create HFT profile and group with multiple counters
+        self.create_hft_profile(dvs)
+        self.create_hft_group(dvs,
+                              object_names="Ethernet0,Ethernet4,Ethernet8",
+                              object_counters="IF_IN_OCTETS,IF_IN_UCAST_PKTS,"
+                                              "IF_IN_DISCARDS")
+
+        # Wait for objects to be created
+        time.sleep(5)
+
+        # Verify ASIC objects are created (3 objects × 3 counters = 9
+        # subscriptions)
+        asic_db = self.get_asic_db_objects(dvs)
+        self.verify_asic_db_objects(asic_db, groups=[(3, 3)])
+
+        # Clean up group
+        self.delete_hft_group(dvs)
+        time.sleep(2)
+
+        # Verify counter subscriptions are cleaned up
+        asic_db = self.get_asic_db_objects(dvs)
+        self.verify_asic_db_objects(asic_db, groups=[])
+
+        # Clean up profile
+        self.delete_hft_profile(dvs)
+
+    def test_hft_delete_group_and_rejoin(self, dvs, testlog):
+        """Test HFT group deletion and recreation."""
+        # Create HFT profile and group
+        self.create_hft_profile(dvs)
+        self.create_hft_group(dvs,
+                              object_names="Ethernet0,Ethernet4,Ethernet8",
+                              object_counters="IF_IN_OCTETS,IF_IN_UCAST_PKTS,"
+                                              "IF_IN_DISCARDS")
+
+        # Wait for objects to be created
+        time.sleep(5)
+
+        # Verify ASIC objects are created
+        asic_db = self.get_asic_db_objects(dvs)
+        self.verify_asic_db_objects(asic_db, groups=[(3, 3)])
+
+        # Delete group
+        self.delete_hft_group(dvs)
+        time.sleep(2)
+
+        # Verify counter subscriptions are cleaned up
+        asic_db = self.get_asic_db_objects(dvs)
+        self.verify_asic_db_objects(asic_db, groups=[])
+
+        # Recreate group
+        self.create_hft_group(dvs,
+                              object_names="Ethernet0,Ethernet4,Ethernet8",
+                              object_counters="IF_IN_OCTETS,IF_IN_UCAST_PKTS,"
+                                              "IF_IN_DISCARDS")
+        time.sleep(5)
+
+        # Verify ASIC objects are created again
+        asic_db = self.get_asic_db_objects(dvs)
+        self.verify_asic_db_objects(asic_db, groups=[(3, 3)])
+
+        # Final cleanup
+        self.delete_hft_group(dvs)
+        time.sleep(2)
+
+        asic_db = self.get_asic_db_objects(dvs)
+        self.verify_asic_db_objects(asic_db, groups=[])
+
+        self.delete_hft_profile(dvs)
+
+    def test_hft_profile_status_disabled(self, dvs, testlog):
+        """Test HFT profile with disabled status."""
+        # Create HFT profile with disabled status
+        self.create_hft_profile(dvs, status="disabled")
+        self.create_hft_group(dvs)
+
+        # Wait
+        time.sleep(3)
+
+        # Verify no TAM objects are created when profile is disabled
+        # When disabled, we should have minimal or no HFT-specific objects
+
+        # Clean up
+        self.delete_hft_group(dvs)
+        self.delete_hft_profile(dvs)
+
+    def test_hft_custom_polling_interval(self, dvs, testlog):
+        """Test HFT with custom polling interval."""
+        # Create HFT profile with custom polling interval
+        self.create_hft_profile(dvs, polling_interval=600)
+        self.create_hft_group(dvs)
+
+        # Wait for objects to be created
+        time.sleep(5)
+
+        # Verify ASIC objects with custom interval
+        asic_db = self.get_asic_db_objects(dvs)
+
+        # Check that report interval matches our setting
+        for tam_report in asic_db["tam_report"].values():
+            assert tam_report["SAI_TAM_REPORT_ATTR_REPORT_INTERVAL"] == \
+                "600", \
+                "Expected tam report report interval to be 600"
+
+        # Clean up
+        self.delete_hft_group(dvs)
+        self.delete_hft_profile(dvs)
+
+
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -286,6 +286,8 @@ class TestPort(object):
             status, fvs = atbl.get(intf)
             assert status, "Error getting value for key"
             attributes = dict(fvs)
+            if attributes.get("SAI_HOSTIF_ATTR_TYPE") != "SAI_HOSTIF_TYPE_NETDEV":
+                continue
             hostif_queue = attributes.get("SAI_HOSTIF_ATTR_QUEUE")
             assert hostif_queue == "7"
 


### PR DESCRIPTION
What I did
This pull request introduces a new high-frequency telemetry (HFT) feature to the orchagent module, adding support for telemetry data collection, configuration, and management. The changes include new classes, utilities, and modifications to integrate the HFT feature into the existing codebase.

High-Frequency Telemetry Feature Additions:
Core HFT Components:
**CounterNameMapUpdater **: Implements functionality to manage counter name mappings, including methods to set and delete mappings and notify the telemetry orchestrator. **HFTelGroup **: Manages telemetry groups, including object and statistics ID updates, and provides methods to check group membership and retrieve object information. **HFTelProfile **: Represents telemetry profiles, handling configuration, state management, and interactions with SAI telemetry objects. **HFTelOrch **: The main orchestrator for high-frequency telemetry, managing telemetry sessions, profiles, and SAI objects. Includes methods for configuration updates and SAI object lifecycle management.

Origin PR: https://github.com/sonic-net/sonic-swss/pull/3759