### PR TITLE
Added proper check for mux nbrs for route delete

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -2046,10 +2046,9 @@ void MuxOrch::removeStandaloneTunnelRoute(IpAddress neighborIp)
     NeighborEntry neighbor;
     MacAddress mac;
 
-    bool nbr_found = gNeighOrch->getNeighborEntry(neighborIp, neighbor, mac);
-
     // remove the route prefix if its not a mux neighbor
-    if(nbr_found == false || !isMuxPortNeighbor(neighborIp, mac, neighbor.alias))
+    if (!gNeighOrch->getNeighborEntry(neighborIp, neighbor, mac) ||
+            !isMuxPortNeighbor(neighborIp, mac, neighbor.alias))
     {
         IpPrefix pfx = neighborIp.to_string();
         remove_route(pfx);

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -2046,7 +2046,10 @@ void MuxOrch::removeStandaloneTunnelRoute(IpAddress neighborIp)
     NeighborEntry neighbor;
     MacAddress mac;
 
-    if(!gNeighOrch->getNeighborEntry(neighborIp, neighbor, mac))
+    bool nbr_found = gNeighOrch->getNeighborEntry(neighborIp, neighbor, mac);
+
+    // remove the route prefix if its not a mux neighbor
+    if(nbr_found == false || !isMuxPortNeighbor(neighborIp, mac, neighbor.alias))
     {
         IpPrefix pfx = neighborIp.to_string();
         remove_route(pfx);


### PR DESCRIPTION
tunnelroutes were not getting removed and route checker was complaining about some unaccounted routes.
Added proper check for mux neighbors to avoid tunnel route deletion. 