### PR TITLE
Update swss dependency on 202412.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1347,7 +1347,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "swss-common"
 version = "0.1.0"
-source = "git+https://github.com/sonic-net/sonic-swss-common.git?branch=master#1484a851dbfdd4b122c361cd7ea03eca0afe5d63"
+source = "git+https://github.com/Azure/sonic-swss-common.msft.git?branch=202412#66ac80ee21460f22c5c334cdc620a961c0bd7e2c"
 dependencies = [
  "bindgen",
  "getset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ itertools = "0.13"
 uuid = { version = "1.15", features = ["v4"] }
 
 # SONiC specific dependencies
-swss-common = { git = "https://github.com/sonic-net/sonic-swss-common.git", branch = "master" }
+swss-common = { git = "https://github.com/Azure/sonic-swss-common.msft.git", branch = "202412" }
 
 # Development dependencies
 tempfile = "3.12"


### PR DESCRIPTION
The current swss 202412 branch is pointing to swss-common master branch for rust packages. This creates problems in build, because there could be changes not being merged into 202412 but being included during build.

To fix this problem, this PR updates the swss-common reference to 202412.