### PR TITLE
Update the COUNTER_DB with the new Port Object-Id when the Port is removed and created when the Port Speed is changed dynamically via GCU

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3517,7 +3517,7 @@ bool PortsOrch::initPort(const PortConfig &port)
                 if ((flex_counters_orch->getQueueCountersState()) || (flex_counters_orch->getQueueWatermarkCountersState()))
                 {
                      auto maxQueueNumber = static_cast<uint32_t>(p.m_queue_ids.size());
-                     addPortBufferQueueCounters(p, 0, maxQueueNumber-1, false);
+                     addPortBufferQueueCounters(p, 0, maxQueueNumber-1, true);
                 }
 
                 if ((flex_counters_orch->getPgCountersState()) || (flex_counters_orch->getPgWatermarkCountersState()))
@@ -3582,7 +3582,7 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     {
          // Remove the Port Queues from COUNTERS_DB
          auto maxQueueNumber = static_cast<uint32_t>(p.m_queue_ids.size());
-         deletePortBufferQueueCounters(p, 0, maxQueueNumber-1, false);
+         deletePortBufferQueueCounters(p, 0, maxQueueNumber-1, true);
     }
 
     if ((flex_counters_orch->getPgCountersState()) || (flex_counters_orch->getPgWatermarkCountersState()))
@@ -7605,7 +7605,7 @@ void PortsOrch::addPortBufferQueueCounters(const Port &port, uint32_t startIndex
 
     for (auto queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
     {
-        if (queueIndex == (uint32_t)port.m_host_tx_queue && skip_host_tx_queue)
+        if (port.m_host_tx_queue_configured && queueIndex == (uint32_t)port.m_host_tx_queue && skip_host_tx_queue)
         {
             continue;
         }
@@ -7670,7 +7670,7 @@ void PortsOrch::deletePortBufferQueueCounters(const Port &port, uint32_t startIn
 
     for (auto queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
     {
-        if (queueIndex == (uint32_t)port.m_host_tx_queue && skip_host_tx_queue)
+        if (port.m_host_tx_queue_configured && queueIndex == (uint32_t)port.m_host_tx_queue && skip_host_tx_queue)
         {
             continue;
         }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3514,6 +3514,18 @@ bool PortsOrch::initPort(const PortConfig &port)
                     m_recircPortRole[alias] = role;
                 }
 
+                if ((flex_counters_orch->getQueueCountersState()) || (flex_counters_orch->getQueueWatermarkCountersState()))
+                {
+                     auto maxQueueNumber = static_cast<uint32_t>(p.m_queue_ids.size());
+                     addPortBufferQueueCounters(p, 0, maxQueueNumber-1, false);
+                }
+
+                if ((flex_counters_orch->getPgCountersState()) || (flex_counters_orch->getPgWatermarkCountersState()))
+                {
+                     auto maxPgNumber = static_cast<uint32_t>(p.m_priority_group_ids.size());
+                     addPortBufferPgCounters(p, 0, maxPgNumber-1);
+                }
+
                 // We have to test the size of m_queue_ids here since it isn't initialized on some platforms (like DPU)
                 if (p.m_host_tx_queue_configured && p.m_queue_ids.size() > p.m_host_tx_queue)
                 {
@@ -3565,6 +3577,19 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     if (flex_counters_orch->getPortBufferDropCountersState())
     {
         port_buffer_drop_stat_manager.clearCounterIdList(p.m_port_id);
+    }
+    if ((flex_counters_orch->getQueueCountersState()) || (flex_counters_orch->getQueueWatermarkCountersState()))
+    {
+         // Remove the Port Queues from COUNTERS_DB
+         auto maxQueueNumber = static_cast<uint32_t>(p.m_queue_ids.size());
+         deletePortBufferQueueCounters(p, 0, maxQueueNumber-1, false);
+    }
+
+    if ((flex_counters_orch->getPgCountersState()) || (flex_counters_orch->getPgWatermarkCountersState()))
+    {
+        // Remove the Priority Groups from COUNTERS_DB
+        auto maxPgNumber = static_cast<uint32_t>(p.m_priority_group_ids.size());
+        deletePortBufferPgCounters(p, 0, maxPgNumber-1);
     }
 
     /* remove port name map from counter table */
@@ -7558,12 +7583,6 @@ void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues, b
 {
     SWSS_LOG_ENTER();
 
-    /* Create the Queue map in the Counter DB */
-    vector<FieldValueTuple> queueVector;
-    vector<FieldValueTuple> queuePortVector;
-    vector<FieldValueTuple> queueIndexVector;
-    vector<FieldValueTuple> queueTypeVector;
-
     auto toks = tokenize(queues, '-');
     auto startIndex = to_uint<uint32_t>(toks[0]);
     auto endIndex = startIndex;
@@ -7571,6 +7590,18 @@ void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues, b
     {
         endIndex = to_uint<uint32_t>(toks[1]);
     }
+    addPortBufferQueueCounters(port, startIndex, endIndex, skip_host_tx_queue);
+}
+
+void PortsOrch::addPortBufferQueueCounters(const Port &port, uint32_t startIndex, uint32_t endIndex, bool skip_host_tx_queue)
+{
+    SWSS_LOG_ENTER();
+
+    /* Create the Queue map in the Counter DB */
+    vector<FieldValueTuple> queueVector;
+    vector<FieldValueTuple> queuePortVector;
+    vector<FieldValueTuple> queueIndexVector;
+    vector<FieldValueTuple> queueTypeVector;
 
     for (auto queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
     {
@@ -7629,6 +7660,13 @@ void PortsOrch::removePortBufferQueueCounters(const Port &port, string queues, b
     {
         endIndex = to_uint<uint32_t>(toks[1]);
     }
+    deletePortBufferQueueCounters(port, startIndex, endIndex, skip_host_tx_queue);
+}
+
+void PortsOrch::deletePortBufferQueueCounters(const Port &port, uint32_t startIndex, uint32_t endIndex, bool skip_host_tx_queue)
+{
+    SWSS_LOG_ENTER();
+
 
     for (auto queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
     {
@@ -7742,12 +7780,6 @@ void PortsOrch::createPortBufferPgCounters(const Port& port, string pgs)
 {
     SWSS_LOG_ENTER();
 
-    /* Create the PG map in the Counter DB */
-    /* Add stat counters to flex_counter */
-    vector<FieldValueTuple> pgVector;
-    vector<FieldValueTuple> pgPortVector;
-    vector<FieldValueTuple> pgIndexVector;
-
     auto toks = tokenize(pgs, '-');
     auto startIndex = to_uint<uint32_t>(toks[0]);
     auto endIndex = startIndex;
@@ -7755,6 +7787,18 @@ void PortsOrch::createPortBufferPgCounters(const Port& port, string pgs)
     {
         endIndex = to_uint<uint32_t>(toks[1]);
     }
+    addPortBufferPgCounters(port, startIndex, endIndex);
+}
+
+void PortsOrch::addPortBufferPgCounters(const Port& port, uint32_t startIndex, uint32_t endIndex)
+{
+    SWSS_LOG_ENTER();
+
+    /* Create the PG map in the Counter DB */
+    /* Add stat counters to flex_counter */
+    vector<FieldValueTuple> pgVector;
+    vector<FieldValueTuple> pgPortVector;
+    vector<FieldValueTuple> pgIndexVector;
 
     for (auto pgIndex = startIndex; pgIndex <= endIndex; pgIndex++)
     {
@@ -7938,6 +7982,12 @@ void PortsOrch::removePortBufferPgCounters(const Port& port, string pgs)
     {
         endIndex = to_uint<uint32_t>(toks[1]);
     }
+    deletePortBufferPgCounters(port, startIndex, endIndex);
+}
+
+void PortsOrch::deletePortBufferPgCounters(const Port& port, uint32_t startIndex, uint32_t endIndex)
+{
+    SWSS_LOG_ENTER();
 
     for (auto pgIndex = startIndex; pgIndex <= endIndex; pgIndex++)
     {

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -185,14 +185,18 @@ public:
     void generateQueueMap(map<string, FlexCounterQueueStates> queuesStateVector);
     uint32_t getNumberOfPortSupportedQueueCounters(string port);
     void createPortBufferQueueCounters(const Port &port, string queues, bool skip_host_tx_queue=true);
+    void addPortBufferQueueCounters(const Port &port, uint32_t startIndex, uint32_t endIndex, bool skip_host_tx_queue=true);
     void removePortBufferQueueCounters(const Port &port, string queues, bool skip_host_tx_queue=true);
+    void deletePortBufferQueueCounters(const Port &port, uint32_t startIndex, uint32_t endIndex, bool skip_host_tx_queue=true);
     void addQueueFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector);
     void addQueueWatermarkFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector);
 
     void generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsStateVector);
     uint32_t getNumberOfPortSupportedPgCounters(string port);
     void createPortBufferPgCounters(const Port &port, string pgs);
+    void addPortBufferPgCounters(const Port& port, uint32_t startIndex, uint32_t endIndex);
     void removePortBufferPgCounters(const Port& port, string pgs);
+    void deletePortBufferPgCounters(const Port& port, uint32_t startIndex, uint32_t endIndex);
     void addPriorityGroupFlexCounters(map<string, FlexCounterPgStates> pgsStateVector);
     void addPriorityGroupWatermarkFlexCounters(map<string, FlexCounterPgStates> pgsStateVector);
 

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -641,8 +641,47 @@ namespace flexcounter_test
         // Do not check the content of port counter since it's large and varies among platforms.
         ASSERT_TRUE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, oid, PORT_COUNTER_ID_LIST));
 
-        // create a routing interface
+        auto it = ports.begin();
+        it++;
+        auto secondPortName= it->first;
+        auto secondPortValues = it->second;
+        Port secondPort;
+        ASSERT_TRUE(gPortsOrch->getPort(secondPortName, secondPort));
+        auto second_oid = secondPort.m_port_id;
+
+        //Verify the Port Stats counter after DEL
         std::deque<KeyOpFieldsValuesTuple> entries;
+        auto port_consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        entries.push_back({secondPortName, "DEL",  {} });
+        port_consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        auto ret = gPortsOrch->getPort(secondPortName, secondPort);
+        if (ret == true)
+        {
+           // Temporary work around since remove_port fails in sonic-sairedis/vslib in remove_internal due
+           // to switch_create doesn't seem to be calling create_internal for the ports when it is called from
+           // portsorch removePort->sai_port_api.remove_port
+            gPortsOrch->removePortFromLanesMap(secondPortName);
+            gPortsOrch->removePortFromPortListMap(secondPort.m_port_id);
+            gPortsOrch->m_portConfigMap.erase(secondPortName);
+            gPortsOrch->m_portList.erase(secondPortName);
+            gPortsOrch->saiOidToAlias.erase(secondPort.m_port_id);
+
+        }
+        ASSERT_FALSE(gPortsOrch->getPort(secondPortName, secondPort));
+        ASSERT_FALSE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, second_oid, PORT_COUNTER_ID_LIST));
+
+        //Verify the Port Stats counter after re-ADD
+        entries.clear();
+        entries.push_back({secondPortName, "SET", secondPortValues});
+        port_consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        ASSERT_TRUE(gPortsOrch->getPort(secondPortName, secondPort));
+        second_oid = secondPort.m_port_id;
+        ASSERT_TRUE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, second_oid, PORT_COUNTER_ID_LIST));
+
+        // create a routing interface
+        entries.clear();
         entries.push_back({firstPort.m_alias, "SET", { {"mtu", "9100"}}});
         auto consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
         consumer->addToSync(entries);


### PR DESCRIPTION
What I did
Remove the Old Port Object Id, Queue id, PG id from COUNTER_DB when the Port is removed. Add the new Port Object Id, Queue Id, PG Id in COUNTER_DB when the Port is created. The tables COUNTERS_QUEUE_PORT_MAP, COUNTERS_PG_PORT_MAP, COUNTERS_PG_INDEX_MAP, COUNTERS_PG_NAME_MAP are updated.
Fixed the issue reported in https://github.com/sonic-net/sonic-buildimage/issues/24385

Why I did it
When the Port Speed is changed via GCU patch, the orchagent removes the Port from SAI and creates the Port in SAI. So the Port Object id changes and the COUNTER_DB was not updated with the new Port Object Id in the above tables.
How I verified it
Verified all the show and clear commands which are related to Port, Queue , PG etc after GCU patch