### PR TITLE
[DPB]: Fix Stale queue counter mappings in COUNTERS_DB post port breakout

### DIFF
--- a/orchagent/high_frequency_telemetry/counternameupdater.cpp
+++ b/orchagent/high_frequency_telemetry/counternameupdater.cpp
@@ -40,18 +40,15 @@ void CounterNameMapUpdater::setCounterNameMap(const std::vector<swss::FieldValue
 {
     SWSS_LOG_ENTER();
 
-    if (gHFTOrch)
+    for (const auto& map : counter_name_maps)
     {
-        for (const auto& map : counter_name_maps)
+        const std::string& counter_name = fvField(map);
+        sai_object_id_t oid = SAI_NULL_OBJECT_ID;
+        if (!fvValue(map).empty())
         {
-            const std::string& counter_name = fvField(map);
-            sai_object_id_t oid = SAI_NULL_OBJECT_ID;
-            if (!fvValue(map).empty())
-            {
-                sai_deserialize_object_id(fvValue(map), oid);
-            }
-            setCounterNameMap(counter_name, oid);
+            sai_deserialize_object_id(fvValue(map), oid);
         }
+        setCounterNameMap(counter_name, oid);
     }
 }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3850,10 +3850,38 @@ bool PortsOrch::initPort(const PortConfig &port)
                     m_recircPortRole[alias] = role;
                 }
 
-                // We have to test the size of m_queue_ids here since it isn't initialized on some platforms (like DPU)
-                if (p.m_host_tx_queue_configured && p.m_queue_ids.size() > p.m_host_tx_queue)
+                // If queue-related flex counters are already enabled, generate queue maps
+                // for the newly added port so that usecases like dynamic port breakout works.
+                bool queueFcEnabled = flex_counters_orch->getQueueCountersState() ||
+                                        flex_counters_orch->getQueueWatermarkCountersState() ||
+                                        flex_counters_orch->getWredQueueCountersState();
+                if (queueFcEnabled && !p.m_queue_ids.empty())
                 {
-                    createPortBufferQueueCounters(p, to_string(p.m_host_tx_queue), false);
+                    auto queuesStateVector = flex_counters_orch->getQueueConfigurations();
+
+                    auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(p.m_alias);
+                    FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
+
+                    if (queuesStateVector.count(p.m_alias))
+                    {
+                        flexCounterQueueState = queuesStateVector.at(p.m_alias);
+                    }
+                    else if (queuesStateVector.count(createAllAvailableBuffersStr))
+                    {
+                        if (maxQueueNumber > 0)
+                        {
+                            flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
+                        }
+                    }
+                    else
+                    {
+                        if (p.m_host_tx_queue_configured && p.m_host_tx_queue <= maxQueueNumber)
+                        {
+                            flexCounterQueueState.enableQueueCounter(p.m_host_tx_queue);
+                        }
+                    }
+
+                    generateQueueMapPerPort(p, flexCounterQueueState, false);
                 }
 
                 SWSS_LOG_NOTICE("Initialized port %s", alias.c_str());
@@ -3886,9 +3914,12 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
         return;
     }
 
-    if (p.m_host_tx_queue_configured && p.m_queue_ids.size() > p.m_host_tx_queue)
+    if (!p.m_queue_ids.empty())
     {
-        removePortBufferQueueCounters(p, to_string(p.m_host_tx_queue), false);
+        auto skip_host_tx_queue = p.m_host_tx_queue_configured && (p.m_queue_ids.size() > p.m_host_tx_queue);
+        // Remove all queue counters and mappings for this port to avoid stale entries
+        std::string range = "0-" + to_string(p.m_queue_ids.size() - 1);
+        removePortBufferQueueCounters(p, range, skip_host_tx_queue);
     }
 
     /* remove port from flex_counter_table for updating counters  */

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3875,7 +3875,7 @@ bool PortsOrch::initPort(const PortConfig &port)
                     }
                     else
                     {
-                        if (p.m_host_tx_queue_configured && p.m_host_tx_queue <= maxQueueNumber)
+                        if (p.m_host_tx_queue_configured && p.m_host_tx_queue < maxQueueNumber)
                         {
                             flexCounterQueueState.enableQueueCounter(p.m_host_tx_queue);
                         }

--- a/tests/mock_tests/mock_table.cpp
+++ b/tests/mock_tests/mock_table.cpp
@@ -116,6 +116,35 @@ namespace swss
             table->second.erase(key);
         }
     }
+
+    void Table::hdel(const std::string &key, const std::string &field, const std::string &op, const std::string &prefix)
+    {
+        auto &table = gDB[m_pipe->getDbId()][getTableName()];
+        auto key_iter = table.find(key);
+        if (key_iter == table.end())
+        {
+            return;
+        }
+
+        auto &attrs = key_iter->second;
+        std::vector<FieldValueTuple> new_attrs;
+        for (const auto &attr : attrs)
+        {
+            if (attr.first != field)
+            {
+                new_attrs.push_back(attr);
+            }
+        }
+
+        if (new_attrs.empty())
+        {
+            table.erase(key);
+        }
+        else
+        {
+            table[key] = new_attrs;
+        }
+    }
     
     void ProducerStateTable::set(const std::string &key,
                                  const std::vector<FieldValueTuple> &values,

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -1332,6 +1332,79 @@ namespace portsorch_test
         _unhook_sai_queue_api();
     }
 
+    TEST_F(PortsOrchTest, PortDeleteQueueCountersCleanup)
+    {
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        std::deque<KeyOpFieldsValuesTuple> entries;
+
+        auto &ports = defaultPortList;
+        ASSERT_TRUE(!ports.empty());
+
+        // Create ports
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { "lanes", "0" } });
+
+        gPortsOrch->addExistingData(&portTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        Port port;
+        auto testQueueIdx = 0;
+        string portName = "Ethernet0";
+        ASSERT_TRUE(gPortsOrch->getPort(portName, port));
+        ASSERT_NE(port.m_port_id, SAI_NULL_OBJECT_ID);
+        ASSERT_GT(port.m_queue_ids.size(), 0u);
+
+        // Enable Queue flex counters
+        Table flexCounterCfg = Table(m_config_db.get(), CFG_FLEX_COUNTER_TABLE_NAME);
+        const std::vector<FieldValueTuple> enable({ {FLEX_COUNTER_STATUS_FIELD, "enable"} });
+        flexCounterCfg.set("QUEUE_WATERMARK", enable);
+        flexCounterCfg.set("QUEUE", enable);
+
+        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+        flexCounterOrch->addExistingData(&flexCounterCfg);
+        static_cast<Orch *>(flexCounterOrch)->doTask();
+
+        sai_object_id_t targetQueueOid = port.m_queue_ids[testQueueIdx];
+
+        // Delete the port
+        entries.push_back({portName, "DEL", { { } }});
+        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        entries.clear();
+
+        Table countersQueueNameMap(m_counters_db.get(), "COUNTERS_QUEUE_NAME_MAP");
+        Table countersQueuePortMap(m_counters_db.get(), "COUNTERS_QUEUE_PORT_MAP");
+
+        // Verify specific alias:idx field is gone from name maps
+        string dummy;
+        ASSERT_FALSE(countersQueueNameMap.hget("", portName + ":" + to_string(testQueueIdx), dummy));
+        ASSERT_FALSE(countersQueuePortMap.hget("", sai_serialize_object_id(targetQueueOid), dummy));
+
+        // Re-add the same port
+        auto it = ports.find(portName);
+        entries.push_back({portName, "SET", it->second});
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        entries.clear();
+
+        // Fetch the re-added port and verify COUNTERS_DB entries exist for the queue index
+        Port readded;
+        ASSERT_TRUE(gPortsOrch->getPort(portName, readded));
+        ASSERT_GT(readded.m_queue_ids.size(), 0u);
+        sai_object_id_t readdedQ1 = readded.m_queue_ids[testQueueIdx];
+
+        // Name-map should contain alias:idx as a field
+        ASSERT_TRUE(countersQueueNameMap.hget("", portName + ":" + to_string(testQueueIdx), dummy));
+        // Port-map should contain queue OID -> port OID mapping as a field
+        ASSERT_TRUE(countersQueuePortMap.hget("", sai_serialize_object_id(readdedQ1), dummy));
+    }
+
     TEST_F(PortsOrchTest, PortPTConfigDefaultTimestampTemplate)
     {
         auto portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);


### PR DESCRIPTION
Fixes #3983 

**What I did**
Added cleanup of COUNTERS_*_NAME_MAP entries for a port during its deinit phase, and regenerated the NAME_MAP tables with fresh OIDs during port init when queue flex counters are already enabled.

**Why I did it**
After dynamic port breakout of a port, queue name map tables in the COUNTERS_DB table are not regenerated leaving stale entries resulting in CLI crash

**How I verified it**
```bash
# show queue counters Ethernet0
For namespace :
     Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
---------  -----  --------------  ---------------  -----------  ------------
Ethernet0    UC0               0                0            0             0
Ethernet0    UC1               0                0            0             0
Ethernet0    UC2               0                0            0             0
Ethernet0    UC3               0                0            0             0
Ethernet0    UC4               0                0            0             0
Ethernet0    UC5               0                0            0             0
Ethernet0    UC6               0                0            0             0
Ethernet0    UC7               0                0            0             0

root@sonic:~# redis-dump -d 2 -k "COUNTERS_PORT_NAME_MAP*" | jq | grep Ethernet448
      "Ethernet448": "oid:0x100000000085c",
root@sonic:~#  redis-dump -d 2 -k "COUNTERS_QUEUE_PORT_MAP*" | jq | grep 0x100000000085c
      "oid:0x15000000000860": "oid:0x100000000085c",
      "oid:0x15000000000861": "oid:0x100000000085c",
      "oid:0x15000000000862": "oid:0x100000000085c",
      "oid:0x15000000000863": "oid:0x100000000085c",
      "oid:0x15000000000864": "oid:0x100000000085c",
      "oid:0x1500000000085d": "oid:0x100000000085c",
      "oid:0x1500000000085f": "oid:0x100000000085c",
      "oid:0x1500000000085e": "oid:0x100000000085c",
root@sonic:~# redis-dump -d 2 -k "COUNTERS_QUEUE_NAME_MAP*" | jq | grep -E "0x15000000000860|0x15000000000861|0x15000000000862|0x15000000000863|0x15000000000864|0x1500000000085d|0x1500000000085f|0x1500000000085e"
      "Ethernet448:6": "oid:0x15000000000863",
      "Ethernet448:2": "oid:0x1500000000085f",
      "Ethernet448:4": "oid:0x15000000000861",
      "Ethernet448:7": "oid:0x15000000000864",
      "Ethernet448:3": "oid:0x15000000000860",
      "Ethernet448:0": "oid:0x1500000000085d",
      "Ethernet448:5": "oid:0x15000000000862",
      "Ethernet448:1": "oid:0x1500000000085e",
root@sonic:~# redis-dump -d 2 -k "COUNTERS_QUEUE_INDEX_MAP*" | jq | grep -E "0x15000000000860|0x15000000000861|0x15000000000862|0x15000000000863|0x15000000000864|0x1500000000085d|0x1500000000085f|0x1500000000085e"
      "oid:0x15000000000860": "3",
      "oid:0x15000000000861": "4",
      "oid:0x15000000000862": "5",
      "oid:0x15000000000863": "6",
      "oid:0x15000000000864": "7",
      "oid:0x1500000000085d": "0",
      "oid:0x1500000000085f": "2",
      "oid:0x1500000000085e": "1",
root@sonic:~#  redis-dump -d 2 -k "COUNTERS_QUEUE_TYPE_MAP*" | jq | grep -E "0x15000000000860|0x15000000000861|0x15000000000862|0x15000000000863|0x15000000000864|0x1500000000085d|0x1500000000085f|0x1500000000085e"
      "oid:0x15000000000860": "SAI_QUEUE_TYPE_UNICAST",
      "oid:0x15000000000861": "SAI_QUEUE_TYPE_UNICAST",
      "oid:0x15000000000862": "SAI_QUEUE_TYPE_UNICAST",
      "oid:0x15000000000863": "SAI_QUEUE_TYPE_UNICAST",
      "oid:0x15000000000864": "SAI_QUEUE_TYPE_UNICAST",
      "oid:0x1500000000085d": "SAI_QUEUE_TYPE_UNICAST",
      "oid:0x1500000000085f": "SAI_QUEUE_TYPE_UNICAST",
      "oid:0x1500000000085e": "SAI_QUEUE_TYPE_UNICAST",
```

**Details if related**
