### PR TITLE
Add support for port media_type

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -175,6 +175,8 @@ public:
     sai_port_interface_type_t m_interface_type = SAI_PORT_INTERFACE_TYPE_NONE;
     std::set<sai_port_interface_type_t> m_adv_interface_types;
     bool      m_mpls = false;
+    std::string m_media_type = "unknown";
+
     /*
      * Following bit vector is used to lock
      * the queue from being changed in BufferOrch.

--- a/orchagent/port/portcnt.h
+++ b/orchagent/port/portcnt.h
@@ -99,6 +99,11 @@ public:
     } link_training; // Port link training
 
     struct {
+        std::string value;
+        bool is_set = false;
+    } media_type; // Port media type
+
+    struct {
 
         struct {
             std::vector<std::uint32_t> value;

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -919,6 +919,22 @@ bool PortHelper::parsePortPtTimestampTemplate(PortConfig &port, const std::strin
     return true;
 }
 
+bool PortHelper::parsePortMediaType(PortConfig &port, const std::string &field, const std::string &value) const
+{
+    SWSS_LOG_ENTER();
+
+    if (value.empty())
+    {
+        SWSS_LOG_ERROR("Failed to parse field(%s): empty string is prohibited", field.c_str());
+        return false;
+    }
+
+    port.media_type.value = value;
+    port.media_type.is_set = true;
+
+    return true;
+}
+
 bool PortHelper::parsePortConfig(PortConfig &port) const
 {
     SWSS_LOG_ENTER();
@@ -1225,6 +1241,13 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         else if (field == PORT_FLAP_PENALTY)
         {
             if (!this->parsePortLinkEventDampingConfig(port.link_event_damping_config.flap_penalty, field, value))
+            {
+                return false;
+            }
+        }
+        else if (field == PORT_MEDIA_TYPE)
+        {
+            if (!this->parsePortMediaType(port, field, value))
             {
                 return false;
             }

--- a/orchagent/port/porthlpr.h
+++ b/orchagent/port/porthlpr.h
@@ -62,4 +62,5 @@ private:
     bool parsePortSubport(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortPtIntfId(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortPtTimestampTemplate(PortConfig &port, const std::string &field, const std::string &value) const;
+    bool parsePortMediaType(PortConfig &port, const std::string &field, const std::string &value) const;
 };

--- a/orchagent/port/portschema.h
+++ b/orchagent/port/portschema.h
@@ -101,3 +101,4 @@
 #define PORT_SUPPRESS_THRESHOLD    "suppress_threshold"
 #define PORT_REUSE_THRESHOLD       "reuse_threshold"
 #define PORT_FLAP_PENALTY          "flap_penalty"
+#define PORT_MEDIA_TYPE            "media_type"

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -102,7 +102,8 @@ static map<string, sai_bridge_port_fdb_learning_mode_t> learn_mode_map =
 static map<string, sai_port_media_type_t> media_type_map =
 {
     { "fiber", SAI_PORT_MEDIA_TYPE_FIBER },
-    { "copper", SAI_PORT_MEDIA_TYPE_COPPER }
+    { "copper", SAI_PORT_MEDIA_TYPE_COPPER },
+    { "backplane", SAI_PORT_MEDIA_TYPE_BACKPLANE}
 };
 
 static map<string, sai_port_internal_loopback_mode_t> loopback_mode_map =
@@ -4624,6 +4625,21 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         }
                     }
                 }
+                if (pCfg.media_type.is_set)
+                {
+                    if (setPortMediaType(p, pCfg.media_type.value))
+                    {
+                        SWSS_LOG_NOTICE("Set port %s Media Type %s is successful",
+                                         p.m_alias.c_str(), pCfg.media_type.value.c_str());
+                    }
+                    else
+                    {
+                        SWSS_LOG_ERROR("Failed to set port %s Media Type %s",
+                                        p.m_alias.c_str(), pCfg.media_type.value.c_str());
+                        it++;
+                        continue;
+                    }
+                }
 
                 /* create host_tx_ready field in state-db */
                 initHostTxReadyState(p);
@@ -8573,6 +8589,35 @@ void PortsOrch::removePortSerdesAttribute(sai_object_id_t port_id)
         }
     }
     SWSS_LOG_NOTICE("Removed port serdes object 0x%" PRIx64 " for port 0x%" PRIx64, port_serdes_id, port_id);
+}
+
+bool PortsOrch::setPortMediaType(Port& port, const string &media_type)
+{
+    sai_attribute_t attr;
+    sai_status_t status;
+
+    if (media_type_map.find(media_type) == media_type_map.end())
+    {
+        SWSS_LOG_NOTICE("Invalid media_type:%s for port %s", media_type.c_str(), port.m_alias.c_str());
+        return false;
+    }
+
+    attr.id = SAI_PORT_ATTR_MEDIA_TYPE;
+    attr.value.u32 = media_type_map[media_type];
+    status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to set Media Type %s 0x%x to port %s, rv:%d",
+                media_type.c_str(), attr.value.u32, port.m_alias.c_str(), status);
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
+    }
+    port.m_media_type = media_type;
+    SWSS_LOG_INFO("Set Media Type %s 0x%x to port pid:%" PRIx64, media_type.c_str(), attr.value.u32, port.m_port_id);
+    return true;
 }
 
 void PortsOrch::getPortSerdesVal(const std::string& val_str,

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -492,6 +492,7 @@ private:
 
 
     void removePortSerdesAttribute(sai_object_id_t port_id);
+    bool setPortMediaType(Port& port, const string &media_type);
 
     bool getSaiAclBindPointType(Port::Type                type,
                                 sai_acl_bind_point_type_t &sai_acl_bind_type);

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -907,19 +907,51 @@ namespace portsorch_test
                 { "obplev",      "0x69,0x6b,0x6a,0x6c"         },
                 { "obnlev",      "0x5f,0x61,0x60,0x62"         },
                 { "regn_bfm1p",  "0x1e,0x20,0x1f,0x21"         },
-                { "regn_bfm1n",  "0xaa,0xac,0xab,0xad"         }
+                { "regn_bfm1n",  "0xaa,0xac,0xab,0xad"         },
+                { "media_type",    "backplane"                 }
             }
         }};
+        std::deque<KeyOpFieldsValuesTuple> kfvList1 = {{"Ethernet0", SET_COMMAND, {{ "media_type",    "" }}}};
+        std::deque<KeyOpFieldsValuesTuple> kfvList2 = {{"Ethernet0", SET_COMMAND, {{ "media_type",    "none" }}}};
+        std::deque<KeyOpFieldsValuesTuple> kfvListDel = {{"Ethernet0", "DEL" , {}}};
+
+        auto fvs = ports.begin()->second;
+
+        auto consumer = dynamic_cast<Consumer*>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        std::deque<KeyOpFieldsValuesTuple> kfvListAdd= {{"Ethernet0", SET_COMMAND , fvs}};
+
+        Port p;
+        //empty media_type should not be processed
+        consumer->addToSync(kfvList1);
+        static_cast<Orch*>(gPortsOrch)->doTask();
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
+        ASSERT_EQ(p.m_media_type, "unknown");
+
+        consumer->addToSync(kfvListDel);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        consumer->addToSync(kfvListAdd);
+        static_cast<Orch*>(gPortsOrch)->doTask();
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
+
+        consumer->addToSync(kfvList2);
+        static_cast<Orch*>(gPortsOrch)->doTask();
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
+        ASSERT_EQ(p.m_media_type, "unknown");
+
+        consumer->addToSync(kfvListDel);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        consumer->addToSync(kfvListAdd);
+        static_cast<Orch*>(gPortsOrch)->doTask();
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
 
         // Refill consumer
-        auto consumer = dynamic_cast<Consumer*>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+
         consumer->addToSync(kfvList);
 
         // Apply configuration
         static_cast<Orch*>(gPortsOrch)->doTask();
 
         // Get port
-        Port p;
         ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
 
         // Verify preemphasis
@@ -989,6 +1021,10 @@ namespace portsorch_test
         // Verify regn_bfm1n
         std::vector<std::uint32_t> regn_bfm1n = { 0xaa, 0xac, 0xab, 0xad };
         ASSERT_EQ(p.m_preemphasis.at(SAI_PORT_SERDES_ATTR_TX_NMOS_VLTG_REG), regn_bfm1n);
+
+        // Verify media_type
+        std::string media_type = "backplane";
+        ASSERT_EQ(p.m_media_type, media_type);
 
         // Dump pending tasks
         std::vector<std::string> taskList;

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -480,6 +480,62 @@ class TestPort(object):
             if fv[0] == "link_event_damping_algorithm":
                 assert fv[1] == "disabled"
 
+  def test_media_type(self, dvs, testlog):
+
+        db = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+
+        tbl = swsscommon.Table(db, "PORT_TABLE")
+        ptbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
+        atbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
+
+        media_name = 'media_type'
+        media_val = ""
+
+        fvs = swsscommon.FieldValuePairs([(media_name, media_val)])
+        ptbl.set("Ethernet0", fvs)
+
+        time.sleep(1)
+
+        # get media_type
+        (status, fvs) = atbl.get(dvs.asicdb.portnamemap["Ethernet0"])
+        assert status == True
+        #empty media_type should be rejected
+        for fv in fvs:
+            assert fv[0] != "SAI_PORT_ATTR_MEDIA_TYPE"
+
+        media_name = 'media_type'
+        media_val = "none"
+        fvs = swsscommon.FieldValuePairs([(media_name, media_val)])
+        ptbl.set("Ethernet0", fvs)
+
+        time.sleep(1)
+
+        # get media_type
+        (status, fvs) = atbl.get(dvs.asicdb.portnamemap["Ethernet0"])
+        assert status == True
+        #"none" media_type should be rejected
+        for fv in fvs:
+            assert fv[0] != "SAI_PORT_ATTR_MEDIA_TYPE"
+
+        media_name = 'media_type'
+        media_val = "backplane"
+        fvs = swsscommon.FieldValuePairs([(media_name, media_val)])
+        ptbl.set("Ethernet0", fvs)
+
+        time.sleep(1)
+
+        # get media_type
+        (status, fvs) = atbl.get(dvs.asicdb.portnamemap["Ethernet0"])
+        assert status == True
+
+        found = False
+        #check the media_type is added in ASIC_DB
+        for fv in fvs:
+            if fv[0] == "SAI_PORT_ATTR_MEDIA_TYPE":
+                assert fv[1] == "SAI_PORT_MEDIA_TYPE_BACKPLANE"
+                found = True
+        assert found == True
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
What I did
Added support to parse the media_type set in PORT_TABLE in APP_DB and set the corresponding SAI attribute in SAI
Why I did it
media_type support was not present in sonic-swss
How I verified it
Added the media_type in media_settings.json file and verified that they are passes to swss, SAI and also got programmed in the Asic. The verification was done in Nokia chassis platform.