### PR TITLE
Added mock_table hset function from sonic-swss to fix mock tests

### DIFF
--- a/tests/mock_tests/mock_table.cpp
+++ b/tests/mock_tests/mock_table.cpp
@@ -99,6 +99,15 @@ namespace swss
         }
     }
 
+    void Table::hset(const std::string &key, const std::string &field, const std::string &value,
+                const std::string& op, const std::string& prefix)
+    {
+        FieldValueTuple fvp(field, value);
+        std::vector<FieldValueTuple> attrs = { fvp };
+
+        Table::set(key, attrs, op, prefix);
+    }
+
     void Table::getKeys(std::vector<std::string> &keys)
     {
         keys.clear();


### PR DESCRIPTION
**What I did**
Added mock_table hset function from sonic-swss to fix mock tests

This function is taken from master

**Why I did it**
`PortDeleteQueueCountersCleanup` mock test is failing because of missing Table::hset in mock_table.cpp


**How I verified it**
Built swss_1.0.0_amd64.deb with and without the fix. Mock_tests pass with the fix.
