### PR TITLE
Respect Cargo.lock for dependencies version (#4028)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,7 +2131,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "swss-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/sonic-swss-common.msft.git?branch=202412#66ac80ee21460f22c5c334cdc620a961c0bd7e2c"
+source = "git+https://github.com/Azure/sonic-swss-common.msft.git?branch=202412#09b150e4948fe07a2e2a9d1071fefbfcdeb6f087"
 dependencies = [
  "bindgen",
  "getset",

--- a/debian/rules
+++ b/debian/rules
@@ -38,14 +38,11 @@ endif
 
 override_dh_auto_configure:
 	dh_auto_configure -- $(configure_opts)
-	# Configure Rust build for countersyncd
-	cargo fetch
-	cargo update -p swss-common
 
 override_dh_auto_build:
 	dh_auto_build
 	# Build and test countersyncd Rust project
-	cargo build --release
+	cargo build --release --locked
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/swss


### PR DESCRIPTION
Why I did it
Currently cargo update will update dependencies in the Cargo.lock file to the latest version on the specified branch. The sonic-swss-common Rust code is possibly not aligned with libswsscommon package, which will make sonic-buildimage build fail.

How I verified it
Verify local sonic-buildimage build passing, even there is sonic-swss-common changes on c-api.