### PR TITLE
Increase Vrf pool to 4k

### DIFF
--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -10,9 +10,9 @@
 #include "warm_restart.h"
 
 #define VRF_TABLE_START 1001
-#define VRF_TABLE_END 2000
+#define VRF_TABLE_END 5097
 #define TABLE_LOCAL_PREF 1001 // after l3mdev-table
-#define MGMT_VRF_TABLE_ID 5000
+#define MGMT_VRF_TABLE_ID 6000
 #define MGMT_VRF          "mgmt"
 
 using namespace swss;

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -254,7 +254,7 @@ class TestVrf(object):
 
         initial_entries_cnt = self.how_many_entries_exist(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER")
 
-        maximum_vrf_cnt = 999
+        maximum_vrf_cnt = 4096
 
         def create_entry(self, tbl, key, pairs):
             fvs = swsscommon.FieldValuePairs(pairs)


### PR DESCRIPTION
Current VRF pool is limited to 999 instances (VRF_TABLE_END=2000, VRF_TABLE_START=1001) which artificially restricts VRF scale even on hardware platforms that support more VRFs. 

