### PR TITLE
[Backport 202506] Add metric to vnet route tunnel request fields

### DIFF
--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -316,6 +316,7 @@ const request_description_t vnet_route_description = {
         { "check_directly_connected", REQ_T_BOOL },
         { "rx_monitor_timer",       REQ_T_UINT },
         { "tx_monitor_timer",       REQ_T_UINT },
+        { "metric",                 REQ_T_UINT }
     },
     { }
 };

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3276,6 +3276,51 @@ class TestVnetOrch(object):
         self.set_admin_status("Ethernet12", "down")
 
 
+    '''
+    Test 33 - Create vnet route tunnel with various metric values
+    '''
+    def test_vnet_orch_33(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        vnet_obj = self.get_vnet_obj()
+
+        tunnel_name = 'tunnel_33'
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, '10.10.10.10')
+        create_vnet_entry(dvs, 'Vnet33', tunnel_name, '10033', "")
+
+        vnet_obj.check_vnet_entry(dvs, 'Vnet33')
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet33', '10033')
+
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '10.10.10.10')
+
+        vnet_obj.fetch_exist_entries(dvs)
+        
+        for i in range(21):
+            create_vnet_routes(dvs, f'0.0.0.{i}/32', 'Vnet33', f'10.10.10.{i}', metric=i)
+            vnet_obj.check_vnet_routes(dvs, 'Vnet33', f'10.10.10.{i}', tunnel_name)
+            check_state_db_routes(dvs, 'Vnet33', f"0.0.0.{i}/32", [f'10.10.10.{i}'])
+
+            entry = self.cdb.get_entry("VNET_ROUTE_TUNNEL", f"Vnet33|0.0.0.{i}/32")
+            assert entry is not None and len(entry) > 0, f"VNET route entry not found in CONFIG DB."
+            assert int(entry.get('metric', -1)) == i, f"VNET route metric mismatch: expected {i}, got {entry.get('metric', -1)}."
+
+            # Clean-up vnet route
+            delete_vnet_routes(dvs, f"0.0.0.{i}/32", 'Vnet33')
+            vnet_obj.check_del_vnet_routes(dvs, 'Vnet33')
+
+            vnet_obj.fetch_exist_entries(dvs)
+
+        # Clean-up and verify remove flows
+        delete_vnet_entry(dvs, "Vnet33")
+        vnet_obj.check_del_vnet_entry(dvs, "Vnet33")
+
+        delete_vxlan_tunnel(dvs, tunnel_name)
+        vnet_obj.check_del_vxlan_tunnel(dvs)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/vnet_lib.py
+++ b/tests/vnet_lib.py
@@ -140,11 +140,11 @@ def delete_vnet_local_routes(dvs, prefix, vnet_name):
     time.sleep(2)
 
 
-def create_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor="", profile="", primary="", monitoring="", rx_monitor_timer=-1, tx_monitor_timer=-1, adv_prefix="", check_directly_connected=False):
-    set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac=mac, vni=vni, ep_monitor=ep_monitor, profile=profile, primary=primary, monitoring=monitoring, rx_monitor_timer=rx_monitor_timer, tx_monitor_timer=tx_monitor_timer, adv_prefix=adv_prefix, check_directly_connected=check_directly_connected)
+def create_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor="", profile="", primary="", monitoring="", rx_monitor_timer=-1, tx_monitor_timer=-1, adv_prefix="", check_directly_connected=False, metric=-1):
+    set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac=mac, vni=vni, ep_monitor=ep_monitor, profile=profile, primary=primary, monitoring=monitoring, rx_monitor_timer=rx_monitor_timer, tx_monitor_timer=tx_monitor_timer, adv_prefix=adv_prefix, check_directly_connected=check_directly_connected, metric=metric)
 
 
-def set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor="", profile="", primary="", monitoring="", rx_monitor_timer=-1, tx_monitor_timer=-1, adv_prefix="", check_directly_connected=False):
+def set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor="", profile="", primary="", monitoring="", rx_monitor_timer=-1, tx_monitor_timer=-1, adv_prefix="", check_directly_connected=False, metric=-1):
     conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
 
     attrs = [
@@ -180,6 +180,9 @@ def set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor=
 
     if tx_monitor_timer != -1:
         attrs.append(('tx_monitor_timer', str(tx_monitor_timer)))
+
+    if metric >= 0:
+        attrs.append(('metric', str(metric)))
 
     tbl = swsscommon.Table(conf_db, "VNET_ROUTE_TUNNEL")
     fvs = swsscommon.FieldValuePairs(attrs)


### PR DESCRIPTION
Backport for https://github.com/sonic-net/sonic-swss/pull/4119

What I did
Add metric to vnet route tunnel request, so vnet route tunnels can be created with a metric value. Related yang model change: sonic-net/sonic-buildimage#25019

Why I did it
Enable vnet route tunnels to be created with a metric value that can be used to identify type of route.