### PR TITLE
[countersyncd]: align multi-message netlink parsing

### DIFF
--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -76,6 +76,7 @@ impl NetlinkMessageParser {
         }
     }
 
+    /// Mirrors `NLMSG_ALIGN` from `linux/netlink.h` by rounding lengths up to the next 4-byte boundary.
     fn nlmsg_align(len: usize) -> usize {
         (len + 3) & !3
     }

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -156,7 +156,8 @@ impl NetlinkMessageParser {
                 }
             }
 
-            offset += aligned_nl_len;
+            let remaining = self.incomplete_buffer.len() - offset;
+            offset += usize::min(aligned_nl_len, remaining);
         }
 
         // Keep remaining incomplete data for next recv
@@ -1029,7 +1030,7 @@ pub mod test {
     fn append_aligned_mock_netlink_message(buffer: &mut Vec<u8>, payload: &[u8]) {
         let msg = create_mock_netlink_message(payload);
         let msg_len = 20 + payload.len();
-        let aligned_len = (msg_len + 3) & !3;
+        let aligned_len = NetlinkMessageParser::nlmsg_align(msg_len);
 
         buffer.extend_from_slice(&msg[..msg_len]);
         buffer.resize(buffer.len() + (aligned_len - msg_len), 0);

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -76,6 +76,10 @@ impl NetlinkMessageParser {
         }
     }
 
+    fn nlmsg_align(len: usize) -> usize {
+        (len + 3) & !3
+    }
+
     /// Parse buffer that may contain multiple complete and/or incomplete netlink messages
     /// Returns a vector of complete message payloads, where each payload represents 
     /// one complete netlink message (which contains one complete IPFIX message)
@@ -131,9 +135,14 @@ impl NetlinkMessageParser {
                 break;
             }
 
-            // Extract complete message
+            let aligned_nl_len = Self::nlmsg_align(nl_len);
+
+            // Extract complete message without trailing alignment padding
             let message_data = self.incomplete_buffer[offset..offset + nl_len].to_vec();
-            debug!("Found complete message: offset={}, length={}", offset, nl_len);
+            debug!(
+                "Found complete message: offset={}, length={}, aligned_length={}",
+                offset, nl_len, aligned_nl_len
+            );
 
             // Extract payload from this message
             match Self::extract_payload_from_slice(&message_data) {
@@ -147,7 +156,7 @@ impl NetlinkMessageParser {
                 }
             }
 
-            offset += nl_len;
+            offset += aligned_nl_len;
         }
 
         // Keep remaining incomplete data for next recv
@@ -1017,6 +1026,15 @@ pub mod test {
         msg
     }
 
+    fn append_aligned_mock_netlink_message(buffer: &mut Vec<u8>, payload: &[u8]) {
+        let msg = create_mock_netlink_message(payload);
+        let msg_len = 20 + payload.len();
+        let aligned_len = (msg_len + 3) & !3;
+
+        buffer.extend_from_slice(&msg[..msg_len]);
+        buffer.resize(buffer.len() + (aligned_len - msg_len), 0);
+    }
+
     // Use atomic counter instead of unsafe static mut for thread safety
     static SOCKET_COUNT: AtomicUsize = AtomicUsize::new(0);
 
@@ -1255,6 +1273,25 @@ pub mod test {
         let payload2_str = String::from_utf8(messages[1].to_vec()).unwrap();
         assert_eq!(payload1_str, "MESSAGE1");
         assert_eq!(payload2_str, "MESSAGE2");
+    }
+
+    /// Tests handling multiple aligned messages where the first message length
+    /// is not a multiple of 4 and therefore requires netlink padding.
+    #[test]
+    fn test_multiple_aligned_messages_in_buffer() {
+        let mut combined_buffer = Vec::new();
+
+        append_aligned_mock_netlink_message(&mut combined_buffer, b"A");
+        append_aligned_mock_netlink_message(&mut combined_buffer, b"SECOND");
+
+        let mut parser = NetlinkMessageParser::new();
+        let result = parser.parse_buffer(&combined_buffer);
+        assert!(result.is_ok());
+
+        let messages = result.unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(String::from_utf8(messages[0].to_vec()).unwrap(), "A");
+        assert_eq!(String::from_utf8(messages[1].to_vec()).unwrap(), "SECOND");
     }
 
     /// Tests handling fragmented messages across multiple recv operations.


### PR DESCRIPTION
**What I did**

Backported sonic-net/sonic-swss#4317 to the `202412` branch.

This preserves the aligned multi-message netlink parsing fixes in `countersyncd`, including the follow-up bounds tightening and helper documentation update.

**Why I did it**

The parser needs to align netlink message traversal correctly to avoid malformed multi-message parsing and out-of-bounds behavior.

**How I verified it**

Backport was validated as part of the combined 202412 `countersyncd` stack verification.

A merged 202412 build containing the backports of public PRs 4316/4317/4318/4319 was built and deployed to DUT `str4-sn5640-2`, then the full HFT regression was run:

- `high_frequency_telemetry/test_high_frequency_telemetry.py`
- result: `tests=14`, `failures=0`, `errors=0`, `skipped=7`
- image: `20241212.54`

**Details if related**

Source public PR: https://github.com/sonic-net/sonic-swss/pull/4317
