### PR TITLE
[countersyncd]: resolve labels via object ids

### DIFF
--- a/crates/countersyncd/benches/ipfix_bench_data.rs
+++ b/crates/countersyncd/benches/ipfix_bench_data.rs
@@ -83,7 +83,7 @@ impl PreparedDataset {
 
         let template_messages = key_to_templates
             .into_iter()
-            .map(|(key, bytes)| IPFixTemplatesMessage::new(key, Arc::new(bytes), None))
+            .map(|(key, bytes)| IPFixTemplatesMessage::new(key, Arc::new(bytes), None, None))
             .collect();
 
         Self {

--- a/crates/countersyncd/src/actor/ipfix.rs
+++ b/crates/countersyncd/src/actor/ipfix.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap as StdHashMap, collections::LinkedList, rc::Rc, time::SystemTime};
+use std::{cell::RefCell, collections::LinkedList, rc::Rc, time::SystemTime};
 
 use ahash::{HashMap, HashMapExt};
 use byteorder::{ByteOrder, NetworkEndian};
@@ -500,7 +500,7 @@ pub struct IpfixActor {
     /// Mapping from message key to template IDs for applied templates
     applied_templates_map: HashMap<String, Vec<u16>>,
     /// Precomputed lookup from object ID/label to object name for O(1) stat resolution
-    object_id_name_map: StdHashMap<String, StdHashMap<u16, String>>,
+    object_id_name_map: HashMap<String, HashMap<u16, String>>,
 }
 
 impl IpfixActor {
@@ -524,7 +524,7 @@ impl IpfixActor {
             record_recipient,
             temporary_templates_map: HashMap::new(),
             applied_templates_map: HashMap::new(),
-            object_id_name_map: StdHashMap::new(),
+            object_id_name_map: HashMap::new(),
         }
     }
 
@@ -623,14 +623,28 @@ impl IpfixActor {
 
         if let (Some(object_names), Some(object_ids)) = (&templates.object_names, &templates.object_ids) {
             if object_ids.len() == object_names.len() {
-                self.object_id_name_map.insert(
-                    templates.key.clone(),
-                    object_ids
-                        .iter()
-                        .copied()
-                        .zip(object_names.iter().cloned())
-                        .collect(),
-                );
+                let mut lookup = HashMap::with_capacity(object_ids.len());
+                let mut has_duplicate_object_id = false;
+
+                for (object_id, object_name) in object_ids.iter().copied().zip(object_names.iter().cloned()) {
+                    if let Some(previous_name) = lookup.insert(object_id, object_name.clone()) {
+                        warn!(
+                            "IPFIX template key {} contains duplicate object_id {} ({} -> {}). Skipping object_id_name_map entry to avoid ambiguous label resolution.",
+                            templates.key,
+                            object_id,
+                            previous_name,
+                            object_name
+                        );
+                        has_duplicate_object_id = true;
+                        break;
+                    }
+                }
+
+                if has_duplicate_object_id {
+                    self.object_id_name_map.remove(&templates.key);
+                } else {
+                    self.object_id_name_map.insert(templates.key.clone(), lookup);
+                }
             } else {
                 warn!(
                     "IPFIX template object_ids/object_names length mismatch for key {}: ids={}, names={}. Skipping object_id_name_map entry.",

--- a/crates/countersyncd/src/actor/ipfix.rs
+++ b/crates/countersyncd/src/actor/ipfix.rs
@@ -501,6 +501,8 @@ pub struct IpfixActor {
     applied_templates_map: HashMap<String, Vec<u16>>,
     /// Mapping from message key to object names for converting label IDs
     object_names_map: HashMap<String, Vec<String>>,
+    /// Mapping from message key to object IDs aligned positionally with object_names
+    object_ids_map: HashMap<String, Vec<u16>>,
 }
 
 impl IpfixActor {
@@ -525,6 +527,7 @@ impl IpfixActor {
             temporary_templates_map: HashMap::new(),
             applied_templates_map: HashMap::new(),
             object_names_map: HashMap::new(),
+            object_ids_map: HashMap::new(),
         }
     }
 
@@ -608,8 +611,8 @@ impl IpfixActor {
         };
 
         debug!(
-            "Processing IPFIX templates for key: {}, object_names: {:?}",
-            templates.key, templates.object_names
+            "Processing IPFIX templates for key: {}, object_names: {:?}, object_ids: {:?}",
+            templates.key, templates.object_names, templates.object_ids
         );
 
         // Add detailed debug logging for template content if debug level is enabled
@@ -621,10 +624,18 @@ impl IpfixActor {
             }
         }
 
-        // Store object names if provided
         if let Some(object_names) = &templates.object_names {
             self.object_names_map
                 .insert(templates.key.clone(), object_names.clone());
+        } else {
+            self.object_names_map.remove(&templates.key);
+        }
+
+        if let Some(object_ids) = &templates.object_ids {
+            self.object_ids_map
+                .insert(templates.key.clone(), object_ids.clone());
+        } else {
+            self.object_ids_map.remove(&templates.key);
         }
 
         let cache_ref = Self::get_cache();
@@ -692,8 +703,9 @@ impl IpfixActor {
         self.temporary_templates_map
             .retain(|_, msg_key| msg_key != key);
 
-        // Remove object names for this key
+        // Remove object metadata for this key
         self.object_names_map.remove(key);
+        self.object_ids_map.remove(key);
 
         debug!("Template deletion completed for key: {}", key);
     }
@@ -879,9 +891,14 @@ impl IpfixActor {
                                 .and_then(|key| self.object_names_map.get(key))
                                 .map(|names| names.as_slice())
                                 .unwrap_or(&[]);
+                            let object_ids = template_key
+                                .as_ref()
+                                .and_then(|key| self.object_ids_map.get(key))
+                                .map(|ids| ids.as_slice())
+                                .unwrap_or(&[]);
 
                             // Create SAIStat directly
-                            let stat = SAIStat::from_ipfix(field_spec, val, object_names);
+                            let stat = SAIStat::from_ipfix(field_spec, val, object_names, object_ids);
                             debug!("Created SAIStat: {:?}", stat);
                             final_stats.push(stat);
                         }
@@ -1216,6 +1233,7 @@ mod test {
                 String::from("test_key"),
                 Arc::new(Vec::from(template_bytes)),
                 Some(vec!["Ethernet0".to_string(), "Ethernet1".to_string()]),
+                Some(vec![1, 2]),
             ))
             .await
             .unwrap();

--- a/crates/countersyncd/src/actor/ipfix.rs
+++ b/crates/countersyncd/src/actor/ipfix.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::LinkedList, rc::Rc, time::SystemTime};
+use std::{cell::RefCell, collections::HashMap as StdHashMap, collections::LinkedList, rc::Rc, time::SystemTime};
 
 use ahash::{HashMap, HashMapExt};
 use byteorder::{ByteOrder, NetworkEndian};
@@ -503,6 +503,8 @@ pub struct IpfixActor {
     object_names_map: HashMap<String, Vec<String>>,
     /// Mapping from message key to object IDs aligned positionally with object_names
     object_ids_map: HashMap<String, Vec<u16>>,
+    /// Precomputed lookup from object ID/label to object name for O(1) stat resolution
+    object_id_name_map: StdHashMap<String, StdHashMap<u16, String>>,
 }
 
 impl IpfixActor {
@@ -528,6 +530,7 @@ impl IpfixActor {
             applied_templates_map: HashMap::new(),
             object_names_map: HashMap::new(),
             object_ids_map: HashMap::new(),
+            object_id_name_map: StdHashMap::new(),
         }
     }
 
@@ -638,6 +641,19 @@ impl IpfixActor {
             self.object_ids_map.remove(&templates.key);
         }
 
+        if let (Some(object_names), Some(object_ids)) = (&templates.object_names, &templates.object_ids) {
+            self.object_id_name_map.insert(
+                templates.key.clone(),
+                object_ids
+                    .iter()
+                    .copied()
+                    .zip(object_names.iter().cloned())
+                    .collect(),
+            );
+        } else {
+            self.object_id_name_map.remove(&templates.key);
+        }
+
         let cache_ref = Self::get_cache();
         let cache = cache_ref.borrow_mut();
         let mut read_size: usize = 0;
@@ -706,6 +722,7 @@ impl IpfixActor {
         // Remove object metadata for this key
         self.object_names_map.remove(key);
         self.object_ids_map.remove(key);
+        self.object_id_name_map.remove(key);
 
         debug!("Template deletion completed for key: {}", key);
     }
@@ -885,20 +902,12 @@ impl IpfixActor {
                                 }
                             }
 
-                            // Get object names for this template key
-                            let object_names = template_key
+                            let object_name_lookup = template_key
                                 .as_ref()
-                                .and_then(|key| self.object_names_map.get(key))
-                                .map(|names| names.as_slice())
-                                .unwrap_or(&[]);
-                            let object_ids = template_key
-                                .as_ref()
-                                .and_then(|key| self.object_ids_map.get(key))
-                                .map(|ids| ids.as_slice())
-                                .unwrap_or(&[]);
+                                .and_then(|key| self.object_id_name_map.get(key));
 
                             // Create SAIStat directly
-                            let stat = SAIStat::from_ipfix(field_spec, val, object_names, object_ids);
+                            let stat = SAIStat::from_ipfix(field_spec, val, object_name_lookup);
                             debug!("Created SAIStat: {:?}", stat);
                             final_stats.push(stat);
                         }

--- a/crates/countersyncd/src/actor/ipfix.rs
+++ b/crates/countersyncd/src/actor/ipfix.rs
@@ -499,10 +499,6 @@ pub struct IpfixActor {
     temporary_templates_map: HashMap<u16, String>,
     /// Mapping from message key to template IDs for applied templates
     applied_templates_map: HashMap<String, Vec<u16>>,
-    /// Mapping from message key to object names for converting label IDs
-    object_names_map: HashMap<String, Vec<String>>,
-    /// Mapping from message key to object IDs aligned positionally with object_names
-    object_ids_map: HashMap<String, Vec<u16>>,
     /// Precomputed lookup from object ID/label to object name for O(1) stat resolution
     object_id_name_map: StdHashMap<String, StdHashMap<u16, String>>,
 }
@@ -528,8 +524,6 @@ impl IpfixActor {
             record_recipient,
             temporary_templates_map: HashMap::new(),
             applied_templates_map: HashMap::new(),
-            object_names_map: HashMap::new(),
-            object_ids_map: HashMap::new(),
             object_id_name_map: StdHashMap::new(),
         }
     }
@@ -627,29 +621,25 @@ impl IpfixActor {
             }
         }
 
-        if let Some(object_names) = &templates.object_names {
-            self.object_names_map
-                .insert(templates.key.clone(), object_names.clone());
-        } else {
-            self.object_names_map.remove(&templates.key);
-        }
-
-        if let Some(object_ids) = &templates.object_ids {
-            self.object_ids_map
-                .insert(templates.key.clone(), object_ids.clone());
-        } else {
-            self.object_ids_map.remove(&templates.key);
-        }
-
         if let (Some(object_names), Some(object_ids)) = (&templates.object_names, &templates.object_ids) {
-            self.object_id_name_map.insert(
-                templates.key.clone(),
-                object_ids
-                    .iter()
-                    .copied()
-                    .zip(object_names.iter().cloned())
-                    .collect(),
-            );
+            if object_ids.len() == object_names.len() {
+                self.object_id_name_map.insert(
+                    templates.key.clone(),
+                    object_ids
+                        .iter()
+                        .copied()
+                        .zip(object_names.iter().cloned())
+                        .collect(),
+                );
+            } else {
+                warn!(
+                    "IPFIX template object_ids/object_names length mismatch for key {}: ids={}, names={}. Skipping object_id_name_map entry.",
+                    templates.key,
+                    object_ids.len(),
+                    object_names.len()
+                );
+                self.object_id_name_map.remove(&templates.key);
+            }
         } else {
             self.object_id_name_map.remove(&templates.key);
         }
@@ -720,8 +710,6 @@ impl IpfixActor {
             .retain(|_, msg_key| msg_key != key);
 
         // Remove object metadata for this key
-        self.object_names_map.remove(key);
-        self.object_ids_map.remove(key);
         self.object_id_name_map.remove(key);
 
         debug!("Template deletion completed for key: {}", key);

--- a/crates/countersyncd/src/actor/swss.rs
+++ b/crates/countersyncd/src/actor/swss.rs
@@ -1,7 +1,7 @@
 use super::super::message::ipfix::IPFixTemplatesMessage;
 use swss_common::{DbConnector, KeyOperation, SubscriberStateTable};
 
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::Sender;
@@ -232,7 +232,7 @@ impl SwssActor {
         let templates = Arc::new(session_data.session_config.clone());
 
         // Parse object_names if present
-        let object_names = if session_data.object_names.is_empty() {
+        let object_names: Option<Vec<String>> = if session_data.object_names.is_empty() {
             None
         } else {
             Some(
@@ -248,13 +248,45 @@ impl SwssActor {
         let object_ids = if session_data.object_ids.is_empty() {
             None
         } else {
-            Some(
-                session_data
-                    .object_ids
-                    .split(',')
-                    .filter_map(|s| s.trim().parse::<u16>().ok())
-                    .collect(),
-            )
+            let mut parsed_object_ids = Vec::new();
+            for token in session_data.object_ids.split(',') {
+                let trimmed = token.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+
+                match trimmed.parse::<u16>() {
+                    Ok(object_id) => parsed_object_ids.push(object_id),
+                    Err(e) => {
+                        warn!(
+                            "Invalid object_ids entry '{}' for session {}: {}. Ignoring object_ids for this update",
+                            trimmed,
+                            key,
+                            e
+                        );
+                        parsed_object_ids.clear();
+                        break;
+                    }
+                }
+            }
+
+            if parsed_object_ids.is_empty() {
+                None
+            } else if let Some(names) = object_names.as_ref() {
+                if names.len() != parsed_object_ids.len() {
+                    warn!(
+                        "object_ids/object_names length mismatch for session {}: {} ids vs {} names. Ignoring object_ids for this update",
+                        key,
+                        parsed_object_ids.len(),
+                        names.len()
+                    );
+                    None
+                } else {
+                    Some(parsed_object_ids)
+                }
+            } else {
+                Some(parsed_object_ids)
+            }
         };
 
         let message = IPFixTemplatesMessage::new(key.to_string(), templates, object_names, object_ids);

--- a/crates/countersyncd/src/actor/swss.rs
+++ b/crates/countersyncd/src/actor/swss.rs
@@ -245,7 +245,19 @@ impl SwssActor {
             )
         };
 
-        let message = IPFixTemplatesMessage::new(key.to_string(), templates, object_names);
+        let object_ids = if session_data.object_ids.is_empty() {
+            None
+        } else {
+            Some(
+                session_data
+                    .object_ids
+                    .split(',')
+                    .filter_map(|s| s.trim().parse::<u16>().ok())
+                    .collect(),
+            )
+        };
+
+        let message = IPFixTemplatesMessage::new(key.to_string(), templates, object_names, object_ids);
 
         // Send to IPFIX actor
         self.template_recipient
@@ -361,8 +373,10 @@ mod tests {
         // Verify object_names parsing
         let object_names = received_message
             .object_names
+            .as_ref()
             .expect("Should have object_names");
-        assert_eq!(object_names, vec!["Ethernet0", "Ethernet1", "Ethernet2"]);
+        assert_eq!(object_names, &vec!["Ethernet0", "Ethernet1", "Ethernet2"]);
+        assert_eq!(received_message.object_ids, Some(vec![1, 2, 3]));
     }
 
     #[tokio::test]
@@ -392,6 +406,7 @@ mod tests {
         assert!(!received_message.is_delete);
         assert!(received_message.templates.is_some());
         assert!(received_message.object_names.is_none());
+        assert_eq!(received_message.object_ids, Some(vec![1]));
     }
 
     #[tokio::test]
@@ -412,6 +427,7 @@ mod tests {
         assert!(received_message.is_delete);
         assert!(received_message.templates.is_none());
         assert!(received_message.object_names.is_none());
+        assert!(received_message.object_ids.is_none());
     }
 
     #[tokio::test]
@@ -482,6 +498,7 @@ mod tests {
         assert!(!received_message.is_delete);
         assert!(received_message.templates.is_some());
         assert!(received_message.object_names.is_none());
+        assert_eq!(received_message.object_ids, Some(vec![1]));
     }
 
     #[test]
@@ -499,15 +516,19 @@ mod tests {
         let templates = Arc::new(vec![1, 2, 3, 4]);
         let object_names = Some(vec!["Ethernet0".to_string(), "Ethernet1".to_string()]);
 
+        let object_ids = Some(vec![1, 2]);
+
         let message = IPFixTemplatesMessage::new(
             "test_key".to_string(),
             templates.clone(),
             object_names.clone(),
+            object_ids.clone(),
         );
 
         assert_eq!(message.key, "test_key");
         assert_eq!(message.templates, Some(templates));
         assert_eq!(message.object_names, object_names);
+        assert_eq!(message.object_ids, object_ids);
         assert!(!message.is_delete);
     }
 
@@ -518,6 +539,7 @@ mod tests {
         assert_eq!(message.key, "test_key");
         assert!(message.templates.is_none());
         assert!(message.object_names.is_none());
+        assert!(message.object_ids.is_none());
         assert!(message.is_delete);
     }
 

--- a/crates/countersyncd/src/message/ipfix.rs
+++ b/crates/countersyncd/src/message/ipfix.rs
@@ -7,15 +7,22 @@ pub struct IPFixTemplatesMessage {
     pub key: String,
     pub templates: Option<IPFixTemplates>,
     pub object_names: Option<Vec<String>>,
+    pub object_ids: Option<Vec<u16>>,
     pub is_delete: bool,
 }
 
 impl IPFixTemplatesMessage {
-    pub fn new(key: String, templates: IPFixTemplates, object_names: Option<Vec<String>>) -> Self {
+    pub fn new(
+        key: String,
+        templates: IPFixTemplates,
+        object_names: Option<Vec<String>>,
+        object_ids: Option<Vec<u16>>,
+    ) -> Self {
         Self {
             key,
             templates: Some(templates),
             object_names,
+            object_ids,
             is_delete: false,
         }
     }
@@ -25,6 +32,7 @@ impl IPFixTemplatesMessage {
             key,
             templates: None,
             object_names: None,
+            object_ids: None,
             is_delete: true,
         }
     }

--- a/crates/countersyncd/src/message/saistats.rs
+++ b/crates/countersyncd/src/message/saistats.rs
@@ -4,7 +4,7 @@
 //! extracted from IPFIX data records. SAI statistics contain information
 //! about switch hardware counters and performance metrics.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use byteorder::{ByteOrder, NetworkEndian};
 use ipfixrw::parser::{DataRecordValue, FieldSpecifier};
@@ -39,8 +39,7 @@ impl SAIStat {
     ///
     /// * `field_spec` - IPFIX field specifier containing identifiers
     /// * `value` - IPFIX data record value containing counter data
-    /// * `object_names` - Vector of object names
-    /// * `object_ids` - Vector of object IDs aligned positionally with object_names
+    /// * `object_name_lookup` - Precomputed map from label/object ID to object name
     ///
     /// # Returns
     ///
@@ -48,8 +47,7 @@ impl SAIStat {
     pub fn from_ipfix(
         field_spec: &FieldSpecifier,
         value: &DataRecordValue,
-        object_names: &[String],
-        object_ids: &[u16],
+        object_name_lookup: Option<&HashMap<u16, String>>,
     ) -> Self {
         let enterprise_number = field_spec.enterprise_number.unwrap_or(0);
         let label = field_spec.information_element_identifier;
@@ -91,15 +89,11 @@ impl SAIStat {
             }
         };
 
-        // Resolve object name from label via object_ids.
-        let object_name = if let Some(index) = object_ids.iter().position(|object_id| *object_id == label) {
-            object_names
-                .get(index)
-                .cloned()
-                .unwrap_or_else(|| format!("unknown_{}", label))
-        } else {
-            format!("unknown_{}", label)
-        };
+        // Resolve object name from label via a precomputed O(1) lookup map.
+        let object_name = object_name_lookup
+            .and_then(|lookup| lookup.get(&label))
+            .cloned()
+            .unwrap_or_else(|| format!("unknown_{}", label));
 
         SAIStat {
             object_name,
@@ -243,6 +237,13 @@ mod tests {
     use super::*;
     use ipfixrw::parser::{DataRecordValue, FieldSpecifier};
 
+    fn build_object_name_lookup(entries: &[(u16, &str)]) -> HashMap<u16, String> {
+        entries
+            .iter()
+            .map(|(object_id, name)| (*object_id, (*name).to_string()))
+            .collect()
+    }
+
     /// Helper function to create a test field specifier
     fn create_field_spec(element_id: u16, enterprise_number: Option<u32>) -> FieldSpecifier {
         FieldSpecifier::new(enterprise_number, element_id, 8)
@@ -259,9 +260,9 @@ mod tests {
     fn test_sai_stat_from_ipfix_basic() {
         let field_spec = create_field_spec(2, Some(0x12340000)); // label 2, type_id 0x1234, stat_id 0
         let value = create_byte_value(12345);
-        let object_names = vec!["Ethernet0".to_string(), "Ethernet1".to_string()];
+        let object_name_lookup = build_object_name_lookup(&[(1, "Ethernet0"), (2, "Ethernet1")]);
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[1, 2]);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, Some(&object_name_lookup));
 
         assert_eq!(stat.object_name, "Ethernet1");
         assert_eq!(stat.type_id, 0x1234);
@@ -275,9 +276,9 @@ mod tests {
         let enterprise_number = 0x80008000 | 0x12340567;
         let field_spec = create_field_spec(1, Some(enterprise_number)); // label 1
         let value = create_byte_value(99999);
-        let object_names = vec!["Ethernet0".to_string()];
+        let object_name_lookup = build_object_name_lookup(&[(1, "Ethernet0")]);
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[1]);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, Some(&object_name_lookup));
 
         assert_eq!(stat.object_name, "Ethernet0");
         assert_eq!(stat.type_id, 0x1234 + EXTENSIONS_RANGE_BASE);
@@ -290,9 +291,9 @@ mod tests {
         let field_spec = create_field_spec(1, Some(0x00010002));
         let short_bytes = vec![0x12, 0x34]; // Only 2 bytes instead of 8
         let value = DataRecordValue::Bytes(short_bytes);
-        let object_names = vec!["Ethernet0".to_string()];
+        let object_name_lookup = build_object_name_lookup(&[(1, "Ethernet0")]);
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[1]);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, Some(&object_name_lookup));
 
         assert_eq!(stat.object_name, "Ethernet0");
         assert_eq!(stat.counter, 0x1234); // Should be padded correctly
@@ -302,9 +303,9 @@ mod tests {
     fn test_sai_stat_from_ipfix_non_bytes() {
         let field_spec = create_field_spec(1, Some(0x00050006));
         let value = DataRecordValue::String("test".to_string());
-        let object_names = vec!["Ethernet0".to_string()];
+        let object_name_lookup = build_object_name_lookup(&[(1, "Ethernet0")]);
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[1]);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, Some(&object_name_lookup));
 
         assert_eq!(stat.object_name, "Ethernet0");
         assert_eq!(stat.counter, 0); // Should default to 0 for non-byte values
@@ -314,9 +315,9 @@ mod tests {
     fn test_sai_stat_from_ipfix_invalid_label() {
         let field_spec = create_field_spec(5, Some(0x00010002)); // label 5, out of range
         let value = create_byte_value(1000);
-        let object_names = vec!["Ethernet0".to_string(), "Ethernet1".to_string()]; // Only 2 objects
+        let object_name_lookup = build_object_name_lookup(&[(1, "Ethernet0"), (2, "Ethernet1")]); // Only 2 objects
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, Some(&object_name_lookup));
 
         assert_eq!(stat.object_name, "unknown_5"); // Fallback for invalid label
         assert_eq!(stat.type_id, 1);
@@ -328,9 +329,9 @@ mod tests {
     fn test_sai_stat_from_ipfix_zero_label() {
         let field_spec = create_field_spec(0, Some(0x00010002)); // label 0, invalid
         let value = create_byte_value(1000);
-        let object_names = vec!["Ethernet0".to_string()];
+        let object_name_lookup = build_object_name_lookup(&[(1, "Ethernet0")]);
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, Some(&object_name_lookup));
 
         assert_eq!(stat.object_name, "unknown_0"); // Fallback for zero label
         assert_eq!(stat.type_id, 1);
@@ -343,10 +344,9 @@ mod tests {
     fn test_sai_stat_from_ipfix_uses_object_ids_mapping() {
         let field_spec = create_field_spec(20, Some(0x00010002));
         let value = create_byte_value(1000);
-        let object_names = vec!["Ethernet0".to_string(), "Ethernet8".to_string()];
-        let object_ids = vec![10, 20];
+        let object_name_lookup = build_object_name_lookup(&[(10, "Ethernet0"), (20, "Ethernet8")]);
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &object_ids);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, Some(&object_name_lookup));
 
         assert_eq!(stat.object_name, "Ethernet8");
         assert_eq!(stat.counter, 1000);
@@ -439,9 +439,9 @@ mod tests {
         let enterprise_number = 0x80008000 | 0x7FFF7FFF; // Maximum values with extensions
         let field_spec = create_field_spec(1, Some(enterprise_number));
         let value = create_byte_value(555);
-        let object_names = vec!["Ethernet0".to_string()];
+        let object_name_lookup = build_object_name_lookup(&[(1, "Ethernet0")]);
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[1]);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, Some(&object_name_lookup));
 
         // Should use saturating_add to prevent overflow
         assert_eq!(stat.type_id, 0x7FFF + EXTENSIONS_RANGE_BASE);

--- a/crates/countersyncd/src/message/saistats.rs
+++ b/crates/countersyncd/src/message/saistats.rs
@@ -91,15 +91,12 @@ impl SAIStat {
             }
         };
 
-        // Resolve object name from label. Prefer explicit object_ids mapping when available,
-        // and fall back to the legacy 1-based positional mapping for backward compatibility.
+        // Resolve object name from label via object_ids.
         let object_name = if let Some(index) = object_ids.iter().position(|object_id| *object_id == label) {
             object_names
                 .get(index)
                 .cloned()
                 .unwrap_or_else(|| format!("unknown_{}", label))
-        } else if object_ids.is_empty() && label > 0 && (label as usize) <= object_names.len() {
-            object_names[(label - 1) as usize].clone()
         } else {
             format!("unknown_{}", label)
         };
@@ -264,9 +261,9 @@ mod tests {
         let value = create_byte_value(12345);
         let object_names = vec!["Ethernet0".to_string(), "Ethernet1".to_string()];
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[1, 2]);
 
-        assert_eq!(stat.object_name, "Ethernet1"); // label 2 -> index 1 (1-based)
+        assert_eq!(stat.object_name, "Ethernet1");
         assert_eq!(stat.type_id, 0x1234);
         assert_eq!(stat.stat_id, 0);
         assert_eq!(stat.counter, 12345);
@@ -280,9 +277,9 @@ mod tests {
         let value = create_byte_value(99999);
         let object_names = vec!["Ethernet0".to_string()];
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[1]);
 
-        assert_eq!(stat.object_name, "Ethernet0"); // label 1 -> index 0 (1-based)
+        assert_eq!(stat.object_name, "Ethernet0");
         assert_eq!(stat.type_id, 0x1234 + EXTENSIONS_RANGE_BASE);
         assert_eq!(stat.stat_id, 0x0567 + EXTENSIONS_RANGE_BASE);
         assert_eq!(stat.counter, 99999);
@@ -295,7 +292,7 @@ mod tests {
         let value = DataRecordValue::Bytes(short_bytes);
         let object_names = vec!["Ethernet0".to_string()];
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[1]);
 
         assert_eq!(stat.object_name, "Ethernet0");
         assert_eq!(stat.counter, 0x1234); // Should be padded correctly
@@ -307,7 +304,7 @@ mod tests {
         let value = DataRecordValue::String("test".to_string());
         let object_names = vec!["Ethernet0".to_string()];
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[1]);
 
         assert_eq!(stat.object_name, "Ethernet0");
         assert_eq!(stat.counter, 0); // Should default to 0 for non-byte values
@@ -444,7 +441,7 @@ mod tests {
         let value = create_byte_value(555);
         let object_names = vec!["Ethernet0".to_string()];
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[1]);
 
         // Should use saturating_add to prevent overflow
         assert_eq!(stat.type_id, 0x7FFF + EXTENSIONS_RANGE_BASE);

--- a/crates/countersyncd/src/message/saistats.rs
+++ b/crates/countersyncd/src/message/saistats.rs
@@ -15,7 +15,7 @@ use ipfixrw::parser::{DataRecordValue, FieldSpecifier};
 /// information about switch hardware counters and their current values.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SAIStat {
-    /// Object name corresponding to the label ID (1-based index from object_names)
+    /// Object name corresponding to the label/object ID mapping
     pub object_name: String,
     /// SAI object type identifier (with possible extensions)
     pub type_id: u32,
@@ -39,7 +39,8 @@ impl SAIStat {
     ///
     /// * `field_spec` - IPFIX field specifier containing identifiers
     /// * `value` - IPFIX data record value containing counter data
-    /// * `object_names` - Vector of object names (1-based indexing)
+    /// * `object_names` - Vector of object names
+    /// * `object_ids` - Vector of object IDs aligned positionally with object_names
     ///
     /// # Returns
     ///
@@ -48,6 +49,7 @@ impl SAIStat {
         field_spec: &FieldSpecifier,
         value: &DataRecordValue,
         object_names: &[String],
+        object_ids: &[u16],
     ) -> Self {
         let enterprise_number = field_spec.enterprise_number.unwrap_or(0);
         let label = field_spec.information_element_identifier;
@@ -89,12 +91,16 @@ impl SAIStat {
             }
         };
 
-        // Resolve object name from label
-        let object_name = if label > 0 && (label as usize) <= object_names.len() {
-            // Convert 1-based label to 0-based index
+        // Resolve object name from label. Prefer explicit object_ids mapping when available,
+        // and fall back to the legacy 1-based positional mapping for backward compatibility.
+        let object_name = if let Some(index) = object_ids.iter().position(|object_id| *object_id == label) {
+            object_names
+                .get(index)
+                .cloned()
+                .unwrap_or_else(|| format!("unknown_{}", label))
+        } else if object_ids.is_empty() && label > 0 && (label as usize) <= object_names.len() {
             object_names[(label - 1) as usize].clone()
         } else {
-            // Fallback to label number if object name not found
             format!("unknown_{}", label)
         };
 
@@ -258,7 +264,7 @@ mod tests {
         let value = create_byte_value(12345);
         let object_names = vec!["Ethernet0".to_string(), "Ethernet1".to_string()];
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
 
         assert_eq!(stat.object_name, "Ethernet1"); // label 2 -> index 1 (1-based)
         assert_eq!(stat.type_id, 0x1234);
@@ -274,7 +280,7 @@ mod tests {
         let value = create_byte_value(99999);
         let object_names = vec!["Ethernet0".to_string()];
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
 
         assert_eq!(stat.object_name, "Ethernet0"); // label 1 -> index 0 (1-based)
         assert_eq!(stat.type_id, 0x1234 + EXTENSIONS_RANGE_BASE);
@@ -289,7 +295,7 @@ mod tests {
         let value = DataRecordValue::Bytes(short_bytes);
         let object_names = vec!["Ethernet0".to_string()];
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
 
         assert_eq!(stat.object_name, "Ethernet0");
         assert_eq!(stat.counter, 0x1234); // Should be padded correctly
@@ -301,7 +307,7 @@ mod tests {
         let value = DataRecordValue::String("test".to_string());
         let object_names = vec!["Ethernet0".to_string()];
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
 
         assert_eq!(stat.object_name, "Ethernet0");
         assert_eq!(stat.counter, 0); // Should default to 0 for non-byte values
@@ -313,7 +319,7 @@ mod tests {
         let value = create_byte_value(1000);
         let object_names = vec!["Ethernet0".to_string(), "Ethernet1".to_string()]; // Only 2 objects
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
 
         assert_eq!(stat.object_name, "unknown_5"); // Fallback for invalid label
         assert_eq!(stat.type_id, 1);
@@ -327,11 +333,25 @@ mod tests {
         let value = create_byte_value(1000);
         let object_names = vec!["Ethernet0".to_string()];
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
 
         assert_eq!(stat.object_name, "unknown_0"); // Fallback for zero label
         assert_eq!(stat.type_id, 1);
         assert_eq!(stat.stat_id, 2);
+        assert_eq!(stat.counter, 1000);
+    }
+
+
+    #[test]
+    fn test_sai_stat_from_ipfix_uses_object_ids_mapping() {
+        let field_spec = create_field_spec(20, Some(0x00010002));
+        let value = create_byte_value(1000);
+        let object_names = vec!["Ethernet0".to_string(), "Ethernet8".to_string()];
+        let object_ids = vec![10, 20];
+
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &object_ids);
+
+        assert_eq!(stat.object_name, "Ethernet8");
         assert_eq!(stat.counter, 1000);
     }
 
@@ -424,7 +444,7 @@ mod tests {
         let value = create_byte_value(555);
         let object_names = vec!["Ethernet0".to_string()];
 
-        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names);
+        let stat = SAIStat::from_ipfix(&field_spec, &value, &object_names, &[]);
 
         // Should use saturating_add to prevent overflow
         assert_eq!(stat.type_id, 0x7FFF + EXTENSIONS_RANGE_BASE);

--- a/crates/countersyncd/src/message/saistats.rs
+++ b/crates/countersyncd/src/message/saistats.rs
@@ -4,8 +4,9 @@
 //! extracted from IPFIX data records. SAI statistics contain information
 //! about switch hardware counters and performance metrics.
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
+use ahash::HashMap;
 use byteorder::{ByteOrder, NetworkEndian};
 use ipfixrw::parser::{DataRecordValue, FieldSpecifier};
 
@@ -349,6 +350,17 @@ mod tests {
         let stat = SAIStat::from_ipfix(&field_spec, &value, Some(&object_name_lookup));
 
         assert_eq!(stat.object_name, "Ethernet8");
+        assert_eq!(stat.counter, 1000);
+    }
+
+    #[test]
+    fn test_sai_stat_from_ipfix_without_lookup_uses_unknown_label() {
+        let field_spec = create_field_spec(20, Some(0x00010002));
+        let value = create_byte_value(1000);
+
+        let stat = SAIStat::from_ipfix(&field_spec, &value, None);
+
+        assert_eq!(stat.object_name, "unknown_20");
         assert_eq!(stat.counter, 1000);
     }
 

--- a/crates/countersyncd/tests/integration_test.rs
+++ b/crates/countersyncd/tests/integration_test.rs
@@ -152,6 +152,7 @@ mod end_to_end_tests {
             "test_session|PORT".to_string(),
             Arc::new(template_data),
             Some(vec!["Ethernet0".to_string(), "Ethernet1".to_string()]),
+            Some(vec![1, 2]),
         );
 
         ipfix_template_sender
@@ -259,6 +260,7 @@ mod end_to_end_tests {
             "direct_test".to_string(),
             Arc::new(template_data),
             Some(vec!["Ethernet0".to_string(), "Ethernet1".to_string()]),
+            Some(vec![1, 2]),
         );
 
         ipfix_template_sender

--- a/crates/countersyncd/tests/ipfix_helpers_integration.rs
+++ b/crates/countersyncd/tests/ipfix_helpers_integration.rs
@@ -63,6 +63,7 @@ async fn ipfix_templates_delete_and_readd_schema_change() {
                     key.to_string(),
                     Arc::new(bytes.clone()),
                     Some(vec!["Obj0".to_string(), "Obj1".to_string()]),
+                    Some(vec![1, 2]),
                 ))
                 .await
                 .expect("template send should succeed");
@@ -164,6 +165,7 @@ async fn ipfix_templates_delete_and_readd_schema_change() {
             delete_key.to_string(),
             Arc::new(readd_templates_bytes.clone()),
             Some(vec!["ObjA".to_string(), "ObjB".to_string()]),
+            Some(vec![1, 2]),
         ))
         .await
         .expect("template re-add should succeed");


### PR DESCRIPTION
**What I did**

Backported sonic-net/sonic-swss#4318 to the `202412` branch.

This brings the object-id based label resolution work for `countersyncd`, including lookup validation and follow-up bookkeeping hardening.

**Why I did it**

The 202412 line needs the same fix so HFT/IPFIX labels are resolved using explicit object IDs instead of fragile positional fallback.

**How I verified it**

Backport was validated as part of the combined 202412 `countersyncd` stack verification.

A merged 202412 build containing the backports of public PRs 4316/4317/4318/4319 was built and deployed to DUT `str4-sn5640-2`, then the full HFT regression was run:

- `high_frequency_telemetry/test_high_frequency_telemetry.py`
- result: `tests=14`, `failures=0`, `errors=0`, `skipped=7`
- image: `20241212.54`

**Details if related**

Source public PR: https://github.com/sonic-net/sonic-swss/pull/4318
