### PR TITLE
[countersyncd]: avoid blocking async actor loops

### DIFF
--- a/crates/countersyncd/src/actor/control_netlink.rs
+++ b/crates/countersyncd/src/actor/control_netlink.rs
@@ -1,10 +1,10 @@
-use std::{thread::sleep, time::Duration};
+use std::time::Duration;
 
 use log::{debug, info, warn};
 
 #[cfg(not(test))]
 use netlink_sys::{protocols::NETLINK_GENERIC, Socket, SocketAddr};
-use tokio::sync::mpsc::Sender;
+use tokio::{sync::mpsc::Sender, time::{interval, MissedTickBehavior}};
 
 use std::io;
 
@@ -386,8 +386,11 @@ impl ControlNetlinkActor {
         let mut heartbeat_counter = 0u32;
         let mut last_periodic_reconnect_counter = 0u32;
         let mut family_was_available = true; // Assume family starts available
+        let mut poll_interval = interval(Duration::from_millis(10));
+        poll_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {
+            poll_interval.tick().await;
             heartbeat_counter += 1;
 
             // Log heartbeat every minute to show the actor is running
@@ -477,9 +480,6 @@ impl ControlNetlinkActor {
                 debug!("Command channel is closed, terminating ControlNetlinkActor");
                 break;
             }
-
-            // Wait a bit before next iteration
-            sleep(Duration::from_millis(10));
         }
 
         debug!("ControlNetlinkActor terminated");

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::LinkedList,
     sync::Arc,
-    thread::sleep,
     time::{Duration, Instant},
 };
 
@@ -14,7 +13,7 @@ use log::{debug, info, warn};
 use netlink_sys::Socket;
 #[cfg(not(test))]
 use netlink_sys::{protocols::NETLINK_GENERIC, SocketAddr};
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::{select, sync::mpsc::{Receiver, Sender}, time::{interval, MissedTickBehavior}};
 
 use std::io;
 
@@ -736,43 +735,6 @@ impl DataNetlinkActor {
         }
     }
 
-    /// Checks for socket readiness without unsafe operations.
-    ///
-    /// This is a safer alternative that uses tokio's timeout mechanism
-    /// instead of direct file descriptor polling with unsafe operations.
-    ///
-    /// # Arguments
-    ///
-    /// * `timeout_ms` - Timeout in milliseconds
-    ///
-    /// # Returns
-    ///
-    /// A boolean indicating if data socket has data
-    async fn check_socket_readiness(timeout_ms: u64) -> Result<bool, io::Error> {
-        // In test environment, always return true to let try_recv() handle the actual data availability
-        #[cfg(test)]
-        {
-            // Simulate minimal polling delay
-            sleep(Duration::from_millis(std::cmp::min(timeout_ms, 1)));
-            // Always return true in test mode - let MockSocket.recv() handle availability
-            return Ok(true);
-        }
-
-        #[cfg(not(test))]
-        {
-            use tokio::time::{sleep as tokio_sleep, Duration as TokioDuration};
-
-            // For production, we simply wait for the timeout period
-            // This approach avoids unsafe operations but is less efficient
-            // The actual socket readiness will be checked by try_recv() calls
-            tokio_sleep(TokioDuration::from_millis(timeout_ms)).await;
-
-            // Always return that data might be ready, let try_recv() handle the actual check
-            // This is safe but potentially less efficient than direct polling
-            Ok(true)
-        }
-    }
-
     /// Continuously processes incoming netlink messages and control commands.
     /// The loop will exit when the command channel is closed or a Close command is received.
     ///
@@ -786,97 +748,92 @@ impl DataNetlinkActor {
         );
         let mut heartbeat_counter = 0u32;
         let mut consecutive_failures = 0u32;
+        let mut poll_interval = interval(Duration::from_millis(SOCKET_READINESS_TIMEOUT_MS));
+        poll_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {
-            // Log heartbeat every 5 minutes to show the actor is running
-            heartbeat_counter += 1;
-            if heartbeat_counter % HEARTBEAT_LOG_INTERVAL == 0 {
-                info!("DataNetlinkActor is running normally - waiting for data messages");
-            }
-
-            // More frequent debug info about socket status
-            if heartbeat_counter % DEBUG_LOG_INTERVAL == 0 {
-                debug!(
-                    "DataNetlinkActor heartbeat: socket={}, recipients={}, failures={}",
-                    actor.socket.is_some(),
-                    actor.buffer_recipients.len(),
-                    consecutive_failures
-                );
-                if actor.socket.is_some() {
-                    debug!("Socket is available and we are actively trying to receive messages");
-                    consecutive_failures = 0; // Reset failure counter when socket is available
-                }
-            }
-
-            // Check for pending commands first (non-blocking)
-            if let Ok(command) = actor.command_recipient.try_recv() {
-                record_comm_stats(
-                    ChannelLabel::ControlNetlinkToDataNetlink,
-                    actor.command_recipient.len(),
-                );
-                match command {
-                    NetlinkCommand::SocketConnect(SocketConnect { family, group }) => {
-                        actor.reset(&family, &group);
-                        consecutive_failures = 0; // Reset failure counter on reconnect command
-                    }
-                    NetlinkCommand::Reconnect => {
-                        actor.connect(true); // Force reconnection
-                        consecutive_failures = 0; // Reset failure counter on reconnect command
-                    }
-                    NetlinkCommand::SoftReconnect => {
-                        actor.connect(false); // Check health before reconnecting
-                        consecutive_failures = 0; // Reset failure counter on reconnect command
-                    }
-                    NetlinkCommand::Close => {
-                        break;
+            select! {
+                command = actor.command_recipient.recv() => {
+                    match command {
+                        Some(command) => {
+                            record_comm_stats(
+                                ChannelLabel::ControlNetlinkToDataNetlink,
+                                actor.command_recipient.len(),
+                            );
+                            match command {
+                                NetlinkCommand::SocketConnect(SocketConnect { family, group }) => {
+                                    actor.reset(&family, &group);
+                                    consecutive_failures = 0;
+                                }
+                                NetlinkCommand::Reconnect => {
+                                    actor.connect(true);
+                                    consecutive_failures = 0;
+                                }
+                                NetlinkCommand::SoftReconnect => {
+                                    actor.connect(false);
+                                    consecutive_failures = 0;
+                                }
+                                NetlinkCommand::Close => {
+                                    break;
+                                }
+                            }
+                        }
+                        None => break,
                     }
                 }
-                continue;
-            }
+                _ = poll_interval.tick() => {
+                    heartbeat_counter += 1;
+                    if heartbeat_counter % HEARTBEAT_LOG_INTERVAL == 0 {
+                        info!("DataNetlinkActor is running normally - waiting for data messages");
+                    }
 
-            // Check socket readiness with configurable timeout to allow periodic checks
-            match Self::check_socket_readiness(SOCKET_READINESS_TIMEOUT_MS).await {
-                Ok(data_ready) => {
-                    // Only try to receive data if we have a socket and data is ready
-                    if actor.socket.is_some() && data_ready {
+                    if heartbeat_counter % DEBUG_LOG_INTERVAL == 0 {
+                        debug!(
+                            "DataNetlinkActor heartbeat: socket={}, recipients={}, failures={}",
+                            actor.socket.is_some(),
+                            actor.buffer_recipients.len(),
+                            consecutive_failures
+                        );
+                        if actor.socket.is_some() {
+                            debug!("Socket is available and we are actively trying to receive messages");
+                            consecutive_failures = 0;
+                        }
+                    }
+
+                    if actor.socket.is_some() {
                         match Self::try_recv(actor.socket.as_mut(), &mut actor.message_parser).await {
                             Ok(messages) => {
-                                consecutive_failures = 0; // Reset failure counter on successful receive
-                                actor.last_data_time = Instant::now(); // Update data reception timestamp
-
+                                consecutive_failures = 0;
+                                actor.last_data_time = Instant::now();
 
                                 if messages.is_empty() {
                                     debug!("Received data but no complete messages yet (partial message)");
                                 } else {
                                     debug!("Successfully parsed {} complete netlink messages", messages.len());
 
-                                    // Send each complete netlink message individually to all recipients
-                                    // This ensures each IPFIX message (contained in one netlink message) 
-                                    // is sent as a separate operation to the downstream actors
                                     for (i, message) in messages.iter().enumerate() {
                                         if log::log_enabled!(log::Level::Debug) {
                                             let hex_dump = format_hex_lines(message.as_ref());
                                             debug!(
-                                                "Outgoing netlink payload {}/{} ({} bytes):\n{}",
+                                                "Outgoing netlink payload {}/{} ({} bytes):
+{}",
                                                 i + 1,
                                                 messages.len(),
                                                 message.len(),
                                                 hex_dump
                                             );
                                         }
-                                        debug!("Processing netlink message {}/{}: {} bytes", 
+                                        debug!("Processing netlink message {}/{}: {} bytes",
                                                i + 1, messages.len(), message.len());
 
-                                        // Send this single netlink message to all recipients
                                         for (j, recipient) in actor.buffer_recipients.iter().enumerate() {
-                                            debug!("Sending netlink message {}/{} to recipient {}", 
+                                            debug!("Sending netlink message {}/{} to recipient {}",
                                                    i + 1, messages.len(), j + 1);
                                             if let Err(e) = recipient.send(message.clone()).await {
-                                                warn!("Failed to send netlink message {}/{} to recipient {}: {:?}", 
+                                                warn!("Failed to send netlink message {}/{} to recipient {}: {:?}",
                                                       i + 1, messages.len(), j + 1, e);
-                                                // Consider removing failed recipients here if needed
                                             } else {
-                                                debug!("Successfully sent netlink message {}/{} ({} bytes) to recipient {}", 
+                                                debug!("Successfully sent netlink message {}/{} ({} bytes) to recipient {}",
                                                        i + 1, messages.len(), message.len(), j + 1);
                                             }
                                         }
@@ -886,51 +843,37 @@ impl DataNetlinkActor {
                                 }
                             }
                             Err(e) => {
-                                // Handle specific errors
                                 if let Some(os_error) = e.raw_os_error() {
                                     if os_error == ENOBUFS {
                                         warn!("Netlink receive buffer full (ENOBUFS). Consider increasing buffer size or processing messages faster. Error: {:?}", e);
-                                        // Don't disconnect on ENOBUFS, just continue
                                         continue;
                                     }
                                 }
 
-                                // Check if it's WouldBlock using standard ErrorKind
                                 if e.kind() == io::ErrorKind::WouldBlock {
-                                    // No data available right now, continue normally
                                     if heartbeat_counter % WOULDBLOCK_LOG_INTERVAL == 0 {
                                         debug!("No netlink data available (WouldBlock) - socket is connected but no messages from kernel");
                                     }
                                 } else {
-                                    // Socket error occurred, disconnect and try limited reconnects
                                     warn!("Failed to receive message: {:?}", e);
                                     actor.disconnect();
                                     consecutive_failures += 1;
 
-                                    // Only attempt very limited local reconnects
                                     if consecutive_failures <= MAX_LOCAL_RECONNECT_ATTEMPTS {
                                         debug!(
                                             "Attempting quick reconnect #{}",
                                             consecutive_failures
                                         );
-                                        actor.connect(true); // Force reconnection on error
+                                        actor.connect(true);
                                     } else {
                                         debug!("Too many consecutive failures, waiting for reconnect command from ControlNetlinkActor");
                                     }
                                 }
                             }
                         }
-                    } else if actor.socket.is_none() {
-                        // No socket available, log this periodically but don't spam
-                        if heartbeat_counter % DEBUG_LOG_INTERVAL == 0 {
-                            debug!("No socket available - waiting for reconnect command from ControlNetlinkActor");
-                        }
+                    } else if heartbeat_counter % DEBUG_LOG_INTERVAL == 0 {
+                        debug!("No socket available - waiting for reconnect command from ControlNetlinkActor");
                     }
-                }
-                Err(e) => {
-                    warn!("Poll error: {:?}", e);
-                    // Wait a bit before retrying to avoid busy loop on persistent poll errors
-                    sleep(Duration::from_millis(SOCKET_READINESS_TIMEOUT_MS));
                 }
             }
         }
@@ -1075,7 +1018,7 @@ pub mod test {
         ///
         /// Ok(size) on success, Err on failure or empty message
         pub fn recv(&mut self, buf: &mut [u8], _flags: i32) -> Result<usize, io::Error> {
-            sleep(Duration::from_millis(1));
+            std::thread::sleep(Duration::from_millis(1));
 
             if self.budget == 0 {
                 // When there are no more messages, return WouldBlock to simulate non-blocking behavior

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -55,8 +55,8 @@ const DEBUG_LOG_INTERVAL: u32 = 3000; // 3000 * 10ms = 30 seconds
 /// WouldBlock debug logging interval (in iterations) - log WouldBlock every minute
 const WOULDBLOCK_LOG_INTERVAL: u32 = 6000; // 6000 * 10ms = 1 minute
 
-/// Socket readiness check timeout in milliseconds
-const SOCKET_READINESS_TIMEOUT_MS: u64 = 10;
+/// Poll interval (ms) for trying a non-blocking netlink recv on the data socket.
+const SOCKET_POLL_INTERVAL_MS: u64 = 10;
 
 /// Maximum size for buffering incomplete messages (1MB)
 const MAX_INCOMPLETE_MESSAGE_SIZE: usize = 1024 * 1024;
@@ -665,6 +665,7 @@ impl DataNetlinkActor {
         #[cfg(not(test))]
         let result = {
             let fd = socket.as_raw_fd();
+            // Safe on the Tokio worker because the fd is already configured as non-blocking.
             unsafe {
                 libc::recv(
                     fd,
@@ -748,7 +749,7 @@ impl DataNetlinkActor {
         );
         let mut heartbeat_counter = 0u32;
         let mut consecutive_failures = 0u32;
-        let mut poll_interval = interval(Duration::from_millis(SOCKET_READINESS_TIMEOUT_MS));
+        let mut poll_interval = interval(Duration::from_millis(SOCKET_POLL_INTERVAL_MS));
         poll_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         loop {

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -815,8 +815,7 @@ impl DataNetlinkActor {
                                         if log::log_enabled!(log::Level::Debug) {
                                             let hex_dump = format_hex_lines(message.as_ref());
                                             debug!(
-                                                "Outgoing netlink payload {}/{} ({} bytes):
-{}",
+                                                "Outgoing netlink payload {}/{} ({} bytes):\n{}",
                                                 i + 1,
                                                 messages.len(),
                                                 message.len(),

--- a/crates/countersyncd/src/actor/swss.rs
+++ b/crates/countersyncd/src/actor/swss.rs
@@ -9,6 +9,7 @@ use tokio::sync::mpsc::{self, Sender};
 const SOCK_PATH: &str = "/var/run/redis/redis.sock";
 const STATE_DB_ID: i32 = 6;
 const STATE_HIGH_FREQUENCY_TELEMETRY_SESSION_TABLE: &str = "HIGH_FREQUENCY_TELEMETRY_SESSION_TABLE";
+const SWSS_EVENT_CHANNEL_CAPACITY: usize = 32;
 
 /// SwssActor is responsible for monitoring SONiC orchestrator agent (orchagent)
 /// messages through the state database. It specifically listens for
@@ -75,7 +76,7 @@ impl SwssActor {
             mut session_table,
             template_recipient,
         } = actor;
-        let (event_sender, mut event_receiver) = mpsc::channel(32);
+        let (event_sender, mut event_receiver) = mpsc::channel(SWSS_EVENT_CHANNEL_CAPACITY);
 
         let _reader_thread = match thread::Builder::new()
             .name("countersyncd-swss".to_string())
@@ -175,7 +176,10 @@ impl SwssActor {
                         }
                         Ok(events)
                     }
-                    Err(e) => Err(format!("Error popping items from session table: {}", e)),
+                    Err(e) => {
+                        error!("Error popping items from session table: {}", e);
+                        Ok(events)
+                    }
                 },
                 swss_common::SelectResult::Timeout => {
                     debug!("Timeout waiting for session table updates");
@@ -235,7 +239,6 @@ impl SwssActor {
     /// # Arguments
     /// * `key` - Session key (e.g., "test|PORT")  
     /// * `field_values` - HashMap of field-value pairs from the state DB
-    #[cfg(test)]
     async fn handle_session_update(
         &mut self,
         key: &str,
@@ -286,7 +289,6 @@ impl SwssActor {
     /// # Arguments
     /// * `key` - Session identifier
     /// * `session_data` - Parsed session configuration
-    #[cfg(test)]
     async fn validate_and_process_session(
         &mut self,
         key: &str,
@@ -358,7 +360,6 @@ impl SwssActor {
     ///
     /// # Arguments
     /// * `key` - Session key that was deleted
-    #[cfg(test)]
     async fn handle_session_delete(&mut self, key: &str) {
         Self::process_session_delete(&self.template_recipient, key).await;
     }

--- a/crates/countersyncd/src/actor/swss.rs
+++ b/crates/countersyncd/src/actor/swss.rs
@@ -84,6 +84,11 @@ impl SwssActor {
                 let mut iteration_count = 0;
 
                 loop {
+                    if event_sender.is_closed() {
+                        debug!("SwssActor event receiver closed, terminating reader thread");
+                        break;
+                    }
+
                     #[cfg(test)]
                     {
                         iteration_count += 1;

--- a/crates/countersyncd/src/actor/swss.rs
+++ b/crates/countersyncd/src/actor/swss.rs
@@ -2,9 +2,9 @@ use super::super::message::ipfix::IPFixTemplatesMessage;
 use swss_common::{DbConnector, KeyOperation, SubscriberStateTable};
 
 use log::{debug, error, info};
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc, thread};
 use std::time::Duration;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{self, Sender};
 
 const SOCK_PATH: &str = "/var/run/redis/redis.sock";
 const STATE_DB_ID: i32 = 6;
@@ -27,6 +27,12 @@ const STATE_HIGH_FREQUENCY_TELEMETRY_SESSION_TABLE: &str = "HIGH_FREQUENCY_TELEM
 pub struct SwssActor {
     pub session_table: SubscriberStateTable,
     template_recipient: Sender<IPFixTemplatesMessage>,
+}
+
+#[derive(Debug)]
+enum SwssEvent {
+    Update { key: String, session_data: SessionData },
+    Delete { key: String },
 }
 
 impl SwssActor {
@@ -58,86 +64,143 @@ impl SwssActor {
     ///
     /// # Arguments
     /// * `actor` - SwssActor instance to run
-    pub async fn run(mut actor: SwssActor) {
+    pub async fn run(actor: SwssActor) {
         info!("SwssActor started, monitoring HIGH_FREQUENCY_TELEMETRY_SESSION_TABLE");
 
         #[cfg(test)]
-        let mut iteration_count = 0;
-        #[cfg(test)]
         const MAX_TEST_ITERATIONS: usize = 20;
 
-        loop {
-            #[cfg(test)]
-            {
-                iteration_count += 1;
-                if iteration_count > MAX_TEST_ITERATIONS {
-                    debug!(
-                        "SwssActor test mode reached maximum iterations ({}), terminating",
-                        MAX_TEST_ITERATIONS
-                    );
-                    break;
-                }
-            }
+        // Keep the SWSS table polling on a dedicated blocking thread so we don't park a Tokio worker.
+        let SwssActor {
+            mut session_table,
+            template_recipient,
+        } = actor;
+        let (event_sender, mut event_receiver) = mpsc::channel(32);
 
-            // Use shorter timeout in test mode to make tests faster
-            #[cfg(test)]
-            let timeout = Duration::from_millis(50);
-            #[cfg(not(test))]
-            let timeout = Duration::from_secs(10);
+        let _reader_thread = thread::Builder::new()
+            .name("countersyncd-swss".to_string())
+            .spawn(move || {
+                #[cfg(test)]
+                let mut iteration_count = 0;
 
-            match actor.session_table.read_data(timeout, false) {
-                Ok(select_result) => {
-                    match select_result {
-                        swss_common::SelectResult::Data => {
-                            // Data available, read it with pops()
-                            match actor.session_table.pops() {
-                                Ok(items) => {
-                                    for item in items {
-                                        debug!(
-                                            "SwssActor received: key={}, op={:?}",
-                                            item.key, item.operation
-                                        );
+                loop {
+                    #[cfg(test)]
+                    {
+                        iteration_count += 1;
+                        if iteration_count > MAX_TEST_ITERATIONS {
+                            debug!(
+                                "SwssActor test mode reached maximum iterations ({}), terminating reader thread",
+                                MAX_TEST_ITERATIONS
+                            );
+                            break;
+                        }
+                    }
 
-                                        let session_key = Self::extract_session_key(&item.key);
-                                        match item.operation {
-                                            KeyOperation::Set => {
-                                                actor
-                                                    .handle_session_update(
-                                                        &session_key,
-                                                        &item.field_values,
-                                                    )
-                                                    .await;
-                                            }
-                                            KeyOperation::Del => {
-                                                actor.handle_session_delete(&session_key).await;
-                                            }
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    error!("Error popping items from session table: {}", e);
+                    #[cfg(test)]
+                    let timeout = Duration::from_millis(50);
+                    #[cfg(not(test))]
+                    let timeout = Duration::from_secs(10);
+
+                    match Self::blocking_collect_events(&mut session_table, timeout) {
+                        Ok(events) => {
+                            for event in events {
+                                if event_sender.blocking_send(event).is_err() {
+                                    debug!("SwssActor event receiver dropped, terminating reader thread");
+                                    return;
                                 }
                             }
                         }
-                        swss_common::SelectResult::Timeout => {
-                            tokio::task::yield_now().await; // Yield to allow other tasks to run after processing template
-                            debug!("Timeout waiting for session table updates");
-                        }
-                        swss_common::SelectResult::Signal => {
-                            debug!("Signal received while waiting for session table updates");
+                        Err(e) => {
+                            error!("Error reading from session table: {}", e);
+                            std::thread::sleep(Duration::from_millis(100));
                         }
                     }
                 }
-                Err(e) => {
-                    error!("Error reading from session table: {}", e);
-                    // Small delay before retrying to avoid busy waiting on persistent errors
-                    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+                #[cfg(test)]
+                debug!("SwssActor reader thread terminated after {} iterations", iteration_count);
+            })
+            .expect("Failed to spawn SwssActor reader thread");
+
+        while let Some(event) = event_receiver.recv().await {
+            match event {
+                SwssEvent::Update { key, session_data } => {
+                    Self::process_session_update(&template_recipient, &key, &session_data).await;
+                }
+                SwssEvent::Delete { key } => {
+                    Self::process_session_delete(&template_recipient, &key).await;
                 }
             }
         }
 
-        #[cfg(test)]
-        debug!("SwssActor terminated after {} iterations", iteration_count);
+        debug!("SwssActor terminated");
+    }
+
+    fn blocking_collect_events(
+        session_table: &mut SubscriberStateTable,
+        timeout: Duration,
+    ) -> Result<Vec<SwssEvent>, String> {
+        let mut events = Vec::new();
+
+        match session_table.read_data(timeout, false) {
+            Ok(select_result) => match select_result {
+                swss_common::SelectResult::Data => match session_table.pops() {
+                    Ok(items) => {
+                        for item in items {
+                            debug!(
+                                "SwssActor received: key={}, op={:?}",
+                                item.key, item.operation
+                            );
+
+                            let session_key = Self::extract_session_key(&item.key);
+                            match item.operation {
+                                KeyOperation::Set => events.push(SwssEvent::Update {
+                                    key: session_key,
+                                    session_data: Self::parse_session_data(&item.field_values),
+                                }),
+                                KeyOperation::Del => {
+                                    events.push(SwssEvent::Delete { key: session_key })
+                                }
+                            }
+                        }
+                        Ok(events)
+                    }
+                    Err(e) => Err(format!("Error popping items from session table: {}", e)),
+                },
+                swss_common::SelectResult::Timeout => {
+                    debug!("Timeout waiting for session table updates");
+                    Ok(events)
+                }
+                swss_common::SelectResult::Signal => {
+                    debug!("Signal received while waiting for session table updates");
+                    Ok(events)
+                }
+            },
+            Err(e) => Err(format!("Error reading from session table: {}", e)),
+        }
+    }
+
+    fn parse_session_data(
+        field_values: &HashMap<String, swss_common::CxxString>,
+    ) -> SessionData {
+        let mut session_data = SessionData::default();
+
+        for (field, value) in field_values {
+            match field.as_str() {
+                "stream_status" => session_data.stream_status = value.to_string_lossy().to_string(),
+                "session_type" => session_data.session_type = value.to_string_lossy().to_string(),
+                "object_names" => session_data.object_names = value.to_string_lossy().to_string(),
+                "object_ids" => session_data.object_ids = value.to_string_lossy().to_string(),
+                "session_config" => {
+                    session_data.session_config = value.as_bytes().to_vec();
+                }
+                _ => {
+                    debug!("Unknown field in session data: {} = {:?}", field, value);
+                }
+            }
+        }
+
+        session_data
     }
 
     /// Extracts the session key from the full Redis key by removing the table name prefix
@@ -162,6 +225,7 @@ impl SwssActor {
     /// # Arguments
     /// * `key` - Session key (e.g., "test|PORT")  
     /// * `field_values` - HashMap of field-value pairs from the state DB
+    #[cfg(test)]
     async fn handle_session_update(
         &mut self,
         key: &str,
@@ -169,25 +233,7 @@ impl SwssActor {
     ) {
         debug!("Processing session update for key: {}", key);
 
-        // Parse session data from field-value pairs
-        let mut session_data = SessionData::default();
-
-        for (field, value) in field_values {
-            match field.as_str() {
-                "stream_status" => session_data.stream_status = value.to_string_lossy().to_string(),
-                "session_type" => session_data.session_type = value.to_string_lossy().to_string(),
-                "object_names" => session_data.object_names = value.to_string_lossy().to_string(),
-                "object_ids" => session_data.object_ids = value.to_string_lossy().to_string(),
-                "session_config" => {
-                    // The session_config contains binary IPFIX template data
-                    // Convert CxxString to Vec<u8>
-                    session_data.session_config = value.as_bytes().to_vec();
-                }
-                _ => {
-                    debug!("Unknown field in session data: {} = {:?}", field, value);
-                }
-            }
-        }
+        let session_data = Self::parse_session_data(field_values);
 
         // Validate and process the session
         if let Err(e) = self.validate_and_process_session(key, &session_data).await {
@@ -195,13 +241,57 @@ impl SwssActor {
         }
     }
 
+    async fn process_session_update(
+        template_recipient: &Sender<IPFixTemplatesMessage>,
+        key: &str,
+        session_data: &SessionData,
+    ) {
+        if let Err(e) = Self::validate_and_send_session(template_recipient, key, session_data).await {
+            error!("Failed to process session {}: {}", key, e);
+        }
+    }
+
+    async fn process_session_delete(
+        template_recipient: &Sender<IPFixTemplatesMessage>,
+        key: &str,
+    ) {
+        info!("Session deleted: {}", key);
+
+        let delete_message = IPFixTemplatesMessage::delete(key.to_string());
+
+        match template_recipient.send(delete_message).await {
+            Ok(_) => {
+                info!("Successfully sent session deletion message for: {}", key);
+            }
+            Err(e) => {
+                error!("Failed to send session deletion message for {}: {}", key, e);
+            }
+        }
+
+        debug!("Session cleanup for {} completed", key);
+    }
+
     /// Validates session data and processes enabled IPFIX sessions
     ///
     /// # Arguments
     /// * `key` - Session identifier
     /// * `session_data` - Parsed session configuration
+    #[cfg(test)]
     async fn validate_and_process_session(
         &mut self,
+        key: &str,
+        session_data: &SessionData,
+    ) -> Result<(), String> {
+        Self::validate_and_send_session(&self.template_recipient, key, session_data).await
+    }
+
+    /// Validates session data and processes enabled IPFIX sessions
+    ///
+    /// # Arguments
+    /// * `key` - Session identifier
+    /// * `session_data` - Parsed session configuration
+    async fn validate_and_send_session(
+        template_recipient: &Sender<IPFixTemplatesMessage>,
         key: &str,
         session_data: &SessionData,
     ) -> Result<(), String> {
@@ -228,10 +318,8 @@ impl SwssActor {
             key, session_data.object_names, session_data.object_ids
         );
 
-        // Create IPFIX templates message
         let templates = Arc::new(session_data.session_config.clone());
 
-        // Parse object_names if present
         let object_names = if session_data.object_names.is_empty() {
             None
         } else {
@@ -247,8 +335,7 @@ impl SwssActor {
 
         let message = IPFixTemplatesMessage::new(key.to_string(), templates, object_names);
 
-        // Send to IPFIX actor
-        self.template_recipient
+        template_recipient
             .send(message)
             .await
             .map_err(|e| format!("Failed to send IPFix templates to recipient: {}", e))?;
@@ -261,22 +348,9 @@ impl SwssActor {
     ///
     /// # Arguments
     /// * `key` - Session key that was deleted
+    #[cfg(test)]
     async fn handle_session_delete(&mut self, key: &str) {
-        info!("Session deleted: {}", key);
-
-        // Send deletion message to IPFIX actor
-        let delete_message = IPFixTemplatesMessage::delete(key.to_string());
-
-        match self.template_recipient.send(delete_message).await {
-            Ok(_) => {
-                info!("Successfully sent session deletion message for: {}", key);
-            }
-            Err(e) => {
-                error!("Failed to send session deletion message for {}: {}", key, e);
-            }
-        }
-
-        debug!("Session cleanup for {} completed", key);
+        Self::process_session_delete(&self.template_recipient, key).await;
     }
 }
 

--- a/crates/countersyncd/src/actor/swss.rs
+++ b/crates/countersyncd/src/actor/swss.rs
@@ -77,7 +77,7 @@ impl SwssActor {
         } = actor;
         let (event_sender, mut event_receiver) = mpsc::channel(32);
 
-        let _reader_thread = thread::Builder::new()
+        let _reader_thread = match thread::Builder::new()
             .name("countersyncd-swss".to_string())
             .spawn(move || {
                 #[cfg(test)]
@@ -119,8 +119,13 @@ impl SwssActor {
 
                 #[cfg(test)]
                 debug!("SwssActor reader thread terminated after {} iterations", iteration_count);
-            })
-            .expect("Failed to spawn SwssActor reader thread");
+            }) {
+                Ok(handle) => handle,
+                Err(e) => {
+                    error!("Failed to spawn SwssActor reader thread: {}", e);
+                    return;
+                }
+            };
 
         while let Some(event) = event_receiver.recv().await {
             match event {


### PR DESCRIPTION
**What I did**

Backported sonic-net/sonic-swss#4319 to the `202412` branch.

This keeps the async actor loop fixes for `countersyncd`, including the follow-up thread-spawn and shutdown handling adjustments.

**Why I did it**

The 202412 line needs the same fixes so `countersyncd` avoids blocking async actor loops and handles the SWSS reader thread lifecycle more safely.

**How I verified it**

Backport was validated as part of the combined 202412 `countersyncd` stack verification.

A merged 202412 build containing the backports of public PRs 4316/4317/4318/4319 was built and deployed to DUT `str4-sn5640-2`, then the full HFT regression was run:

- `high_frequency_telemetry/test_high_frequency_telemetry.py`
- result: `tests=14`, `failures=0`, `errors=0`, `skipped=7`
- image: `20241212.54`

**Details if related**

Source public PR: https://github.com/sonic-net/sonic-swss/pull/4319
