### PR TITLE
[countersyncd]: fix 202412 backport cleanup regressions

### DIFF
--- a/crates/countersyncd/src/actor/ipfix.rs
+++ b/crates/countersyncd/src/actor/ipfix.rs
@@ -667,16 +667,6 @@ impl IpfixActor {
             self.object_id_name_map.remove(&templates.key);
         }
 
-        // Update object name mapping for the session key.
-        // A missing object_names field means the latest template update no longer
-        // provides object name mapping, so any stale value must be cleared.
-        if let Some(object_names) = &templates.object_names {
-            self.object_names_map
-                .insert(templates.key.clone(), object_names.clone());
-        } else {
-            self.object_names_map.remove(&templates.key);
-        }
-
         let cache_ref = Self::get_cache();
         let cache = cache_ref.borrow_mut();
         let mut read_size: usize = 0;
@@ -1229,11 +1219,13 @@ mod test {
             String::from("session_a"),
             Arc::new(Vec::from(template_256_bytes)),
             Some(vec!["Ethernet0".to_string(), "Ethernet1".to_string()]),
+            Some(vec![1, 2]),
         ));
         actor.handle_template(IPFixTemplatesMessage::new(
             String::from("session_b"),
             Arc::new(Vec::from(template_257_bytes)),
             Some(vec!["Ethernet8".to_string(), "Ethernet12".to_string()]),
+            Some(vec![1, 2]),
         ));
 
         let valid_records_bytes: [u8; 144] = [
@@ -1298,21 +1290,23 @@ mod test {
             String::from("session_a"),
             Arc::new(Vec::from(template_bytes)),
             Some(vec!["Ethernet0".to_string(), "Ethernet1".to_string()]),
+            Some(vec![1, 2]),
         ));
-        assert_eq!(
-            actor.object_names_map.get("session_a"),
-            Some(&vec!["Ethernet0".to_string(), "Ethernet1".to_string()])
-        );
+        let mut expected = HashMap::new();
+        expected.insert(1u16, "Ethernet0".to_string());
+        expected.insert(2u16, "Ethernet1".to_string());
+        assert_eq!(actor.object_id_name_map.get("session_a"), Some(&expected));
 
         actor.handle_template(IPFixTemplatesMessage::new(
             String::from("session_a"),
             Arc::new(Vec::from(template_bytes)),
             None,
+            None,
         ));
 
         assert!(
-            actor.object_names_map.get("session_a").is_none(),
-            "stale object_names should be cleared when a template update omits them"
+            actor.object_id_name_map.get("session_a").is_none(),
+            "stale object_id_name_map entries should be cleared when a template update omits object metadata"
         );
     }
 

--- a/crates/countersyncd/src/actor/swss.rs
+++ b/crates/countersyncd/src/actor/swss.rs
@@ -239,6 +239,7 @@ impl SwssActor {
     /// # Arguments
     /// * `key` - Session key (e.g., "test|PORT")  
     /// * `field_values` - HashMap of field-value pairs from the state DB
+    #[cfg(test)]
     async fn handle_session_update(
         &mut self,
         key: &str,
@@ -289,6 +290,7 @@ impl SwssActor {
     /// # Arguments
     /// * `key` - Session identifier
     /// * `session_data` - Parsed session configuration
+    #[cfg(test)]
     async fn validate_and_process_session(
         &mut self,
         key: &str,
@@ -404,6 +406,7 @@ impl SwssActor {
     ///
     /// # Arguments
     /// * `key` - Session key that was deleted
+    #[cfg(test)]
     async fn handle_session_delete(&mut self, key: &str) {
         Self::process_session_delete(&self.template_recipient, key).await;
     }


### PR DESCRIPTION
## What I did

Fix follow-up cleanup regressions in the recent `countersyncd` 202412 backports.

Specifically:
- remove stale `object_names_map` updates left behind after the `object_id_name_map` conversion in `ipfix.rs`
- update `ipfix.rs` tests to use the current `IPFixTemplatesMessage::new(..., object_names, object_ids)` signature
- update the stale-mapping test to validate `object_id_name_map`
- mark legacy `SwssActor` wrapper helpers as `#[cfg(test)]` so non-test builds do not fail under `RUSTFLAGS=-Dwarnings`

## Why I did it

The recent 202412 backport stack for sonic-net/sonic-swss PRs 4316/4317/4318/4319 had two cleanup gaps:

1. `#4318` backport (`41c6d27b`) renamed the actor field to `object_id_name_map` but left stale `object_names_map` references in `ipfix.rs` and related tests.
2. `#4319` backport (`4150bafc`) introduced static helper paths in `swss.rs` while leaving older instance wrapper methods only used by tests, which trips `dead_code` when building with `RUSTFLAGS=-Dwarnings`.

This PR makes the 202412 branch compile and test cleanly again.

## How I verified it

In a CI-like `sonic-slave-bookworm` container:

```bash
RUSTFLAGS=-Dwarnings cargo test --locked --manifest-path crates/countersyncd/Cargo.toml
```

Result:
- unit/integration/doc tests passed
- exit code `0`

## Details if related

This is a fix-up for the recent 202412 backports corresponding to:
- sonic-net/sonic-swss#4316
- sonic-net/sonic-swss#4317
- sonic-net/sonic-swss#4318
- sonic-net/sonic-swss#4319
