### PR TITLE
speed up config reload by bulk-deleting vxlanmgr/vrfmgr netdevs via I…

### DIFF
--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <unistd.h>
 #include "logger.h"
 #include "dbconnector.h"
 #include "producerstatetable.h"
@@ -14,6 +15,8 @@
 #define TABLE_LOCAL_PREF 1001 // after l3mdev-table
 #define MGMT_VRF_TABLE_ID 6000
 #define MGMT_VRF          "mgmt"
+// IFLA_GROUP for vrfmgr-owned VRF netdevs.
+#define VRF_MGR_NETLINK_GROUP   0x534F4E02u
 
 using namespace swss;
 
@@ -111,6 +114,21 @@ VrfMgr::VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
     }
 }
 
+VrfMgr::~VrfMgr()
+{
+    if (WarmStart::isWarmStart())
+    {
+        SWSS_LOG_NOTICE("vrfmgr: warm restart, skipping bulk delete");
+        return;
+    }
+    std::string res;
+    std::ostringstream cmd;
+    cmd << IP_CMD << " link delete group " << VRF_MGR_NETLINK_GROUP << " type vrf";
+    int rc = swss::exec(cmd.str(), res);
+    SWSS_LOG_NOTICE("vrfmgr: bulk delete group 0x%x rc=%d out=%s",
+                    (unsigned)VRF_MGR_NETLINK_GROUP, rc, res.c_str());
+}
+
 uint32_t VrfMgr::getFreeTable(void)
 {
     SWSS_LOG_ENTER();
@@ -188,7 +206,9 @@ bool VrfMgr::setLink(const string& vrfName)
         return false;
     }
 
-    cmd << IP_CMD << " link add " << shellquote(vrfName) << " type vrf table " << table;
+    cmd << IP_CMD << " link add " << shellquote(vrfName)
+        << " group " << VRF_MGR_NETLINK_GROUP
+        << " type vrf table " << table;
     EXEC_WITH_ERROR_THROW(cmd.str(), res);
 
     m_vrfTableMap.emplace(vrfName, table);

--- a/cfgmgr/vrfmgr.h
+++ b/cfgmgr/vrfmgr.h
@@ -18,6 +18,7 @@ class VrfMgr : public Orch
 {
 public:
     VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const std::vector<std::string> &tableNames);
+    ~VrfMgr();
     using Orch::doTask;
     std::string m_evpnVxlanTunnel;
 

--- a/cfgmgr/vrfmgrd.cpp
+++ b/cfgmgr/vrfmgrd.cpp
@@ -1,4 +1,5 @@
 #include <unistd.h>
+#include <signal.h>
 #include <vector>
 #include <mutex>
 #include "dbconnector.h"
@@ -16,6 +17,21 @@ using namespace swss;
 /* select() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 
+static bool received_sigterm = false;
+static struct sigaction old_sigaction;
+
+static void sig_handler(int signo)
+{
+    SWSS_LOG_ENTER();
+
+    if (old_sigaction.sa_handler != SIG_IGN && old_sigaction.sa_handler != SIG_DFL) {
+        old_sigaction.sa_handler(signo);
+    }
+
+    received_sigterm = true;
+    return;
+}
+
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("vrfmgrd");
@@ -26,6 +42,13 @@ int main(int argc, char **argv)
 
     try
     {
+        struct sigaction sigact = {};
+        sigact.sa_handler = sig_handler;
+        if (sigaction(SIGTERM, &sigact, &old_sigaction))
+        {
+            SWSS_LOG_ERROR("failed to setup SIGTERM action handler");
+            exit(EXIT_FAILURE);
+        }
         vector<string> cfg_vrf_tables = {
             CFG_VRF_TABLE_NAME,
             CFG_VNET_TABLE_NAME,
@@ -53,7 +76,7 @@ int main(int argc, char **argv)
         }
 
         SWSS_LOG_NOTICE("starting main loop");
-        while (true)
+        while (!received_sigterm)
         {
             Selectable *sel;
             static bool firstReadTimeout = true;

--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -3,7 +3,7 @@
 #include <regex>
 #include <sstream>
 #include <string>
-#include <net/if.h>
+#include <cstring>
 
 #include "logger.h"
 #include "producerstatetable.h"
@@ -36,6 +36,8 @@ extern MacAddress gMacAddress;
 #define VLAN "vlan"
 #define DST_IP "dst_ip"
 #define SOURCE_VTEP "source_vtep"
+// IFLA_GROUP for vxlanmgr-owned netdevs (vxlan + bridge).
+#define VXLAN_MGR_NETLINK_GROUP   0x534F4E01u
 
 static std::string getVxlanName(const swss::VxlanMgr::VxlanInfo & info)
 {
@@ -53,10 +55,11 @@ static std::string getVxlanIfName(const swss::VxlanMgr::VxlanInfo & info)
 
 static int cmdCreateVxlan(const swss::VxlanMgr::VxlanInfo & info, std::string & res)
 {
-    // ip link add {{VXLAN}} type vxlan id {{VNI}} [local {{SOURCE IP}}] dstport 4789
+    // ip link add {{VXLAN}} group {{VXLAN_MGR_NETLINK_GROUP}} type vxlan id {{VNI}} [local {{SOURCE IP}}] dstport 4789
     ostringstream cmd;
     cmd << IP_CMD " link add "
         << shellquote(info.m_vxlan)
+        << " group " << VXLAN_MGR_NETLINK_GROUP
         << " type vxlan id "
         << shellquote(info.m_vni)
         << " ";
@@ -80,10 +83,11 @@ static int cmdUpVxlan(const swss::VxlanMgr::VxlanInfo & info, std::string & res)
 
 static int cmdCreateVxlanIf(const swss::VxlanMgr::VxlanInfo & info, std::string & res)
 {
-    // ip link add {{VXLAN_IF}} type bridge
+    // ip link add {{VXLAN_IF}} group {{VXLAN_MGR_NETLINK_GROUP}} type bridge
     ostringstream cmd;
     cmd << IP_CMD " link add "
         << shellquote(info.m_vxlanIf)
+        << " group " << VXLAN_MGR_NETLINK_GROUP
         << " type bridge";
     return swss::exec(cmd.str(), res);
 }
@@ -207,7 +211,21 @@ VxlanMgr::VxlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb,
 
 VxlanMgr::~VxlanMgr()
 {
-    clearAllVxlanDevices();
+    if (WarmStart::isWarmStart())
+    {
+        SWSS_LOG_NOTICE("vxlanmgr: warm restart, skipping bulk delete");
+        return;
+    }
+    for (const char *type : {"vxlan", "bridge"})
+    {
+        std::string res;
+        std::ostringstream cmd;
+        cmd << IP_CMD << " link delete group " << VXLAN_MGR_NETLINK_GROUP
+            << " type " << type;
+        int rc = swss::exec(cmd.str(), res);
+        SWSS_LOG_NOTICE("vxlanmgr: bulk delete group 0x%x type %s rc=%d out=%s",
+                        (unsigned)VXLAN_MGR_NETLINK_GROUP, type, rc, res.c_str());
+    }
 }
 
 void VxlanMgr::doTask(Consumer &consumer)
@@ -1009,6 +1027,7 @@ int VxlanMgr::createVxlanNetdevice(std::string vxlanTunnelName, std::string vni_
     // ip link set <vxlan_dev_name> up
 
     link_add_cmd = std::string("") + IP_CMD + " link add " + vxlan_dev_name + 
+                   " group " + std::to_string(VXLAN_MGR_NETLINK_GROUP) +
                    " address " + gMacAddress.to_string() + " type vxlan id " + 
                    std::string(vni_id) + " local " + src_ip + 
                    ((dst_ip  == "")? "":(" remote " + dst_ip)) + 

--- a/cfgmgr/vxlanmgrd.cpp
+++ b/cfgmgr/vxlanmgrd.cpp
@@ -1,4 +1,5 @@
 #include <unistd.h>
+#include <signal.h>
 #include <vector>
 #include <sstream>
 #include <fstream>
@@ -23,6 +24,21 @@ using namespace swss;
 
 MacAddress gMacAddress;
 
+static bool received_sigterm = false;
+static struct sigaction old_sigaction;
+
+static void sig_handler(int signo)
+{
+    SWSS_LOG_ENTER();
+
+    if (old_sigaction.sa_handler != SIG_IGN && old_sigaction.sa_handler != SIG_DFL) {
+        old_sigaction.sa_handler(signo);
+    }
+
+    received_sigterm = true;
+    return;
+}
+
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("vxlanmgrd");
@@ -31,6 +47,13 @@ int main(int argc, char **argv)
 
     try
     {
+        struct sigaction sigact = {};
+        sigact.sa_handler = sig_handler;
+        if (sigaction(SIGTERM, &sigact, &old_sigaction))
+        {
+            SWSS_LOG_ERROR("failed to setup SIGTERM action handler");
+            exit(EXIT_FAILURE);
+        }
 
         DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
@@ -85,7 +108,7 @@ int main(int argc, char **argv)
         }
 
         SWSS_LOG_NOTICE("starting main loop");
-        while (true)
+        while (!received_sigterm)
         {
             Selectable *sel;
             int ret;

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -5,6 +5,7 @@ import pytest
 
 from swsscommon import swsscommon
 from pprint import pprint
+from dvslib.dvs_common import wait_for_result, PollingConfig
 
 
 class TestVrf(object):
@@ -247,6 +248,48 @@ class TestVrf(object):
             self.vrf_update("Vrf_a", req_attr, exp_attr, state)
 
         self.vrf_remove(dvs, "Vrf_a", state)
+
+    def test_VRFMgr_DestructorBulkDelete(self, dvs, testlog):
+        """~VrfMgr() bulk-deletes VRF netdevs via IFLA_GROUP on SIGTERM"""
+        self.setup_db(dvs)
+
+        num_vrfs = 100
+        vrf_group = 0x534F4E02  # matches VRF_MGR_NETLINK_GROUP
+
+        tbl = swsscommon.Table(self.cdb, "VRF")
+        fvs = swsscommon.FieldValuePairs([('empty', 'empty')])
+        vrf_names = [f"Vrf_{i}" for i in range(num_vrfs)]
+        for name in vrf_names:
+            tbl.set(name, fvs)
+
+        def _count_group1000():
+            _, out = dvs.runcmd(['sh', '-c',
+                f"ip -d link show type vrf | grep -c 'group {vrf_group}' || true"])
+            return int(out.strip()) if out.strip() else 0
+
+        wait_for_result(
+            lambda: (_count_group1000() >= num_vrfs, _count_group1000()),
+            polling_config=PollingConfig(polling_interval=1, timeout=60, strict=True),
+            failure_message=f"vrfmgrd did not create {num_vrfs} group-1000 VRFs",
+        )
+
+        # SIGTERM triggers ~VrfMgr() bulk delete
+        dvs.runcmd(['sh', '-c', "supervisorctl stop vrfmgrd"])
+
+        def _check_vrfs_gone():
+            remaining = _count_group1000()
+            return (remaining == 0, remaining)
+
+        try:
+            wait_for_result(
+                _check_vrfs_gone,
+                polling_config=PollingConfig(polling_interval=1, timeout=15, strict=True),
+                failure_message="~VrfMgr() did not bulk-delete group-1000 VRFs on SIGTERM",
+            )
+        finally:
+            for name in vrf_names:
+                tbl._del(name)
+            dvs.runcmd(['sh', '-c', "supervisorctl start vrfmgrd"])
 
     @pytest.mark.xfail(reason="Test unstable, blocking PR builds")
     def test_VRFMgr_Capacity(self, dvs, testlog):

--- a/tests/test_vxlan_tunnel.py
+++ b/tests/test_vxlan_tunnel.py
@@ -6,6 +6,7 @@ import pytest
 
 from swsscommon import swsscommon
 from pprint import pprint
+from dvslib.dvs_common import wait_for_result, PollingConfig
 
 
 def create_entry(tbl, key, pairs):
@@ -410,6 +411,56 @@ def test_vnet_cleanup_config_reload(dvs, env_setup):
     ret, stdout = dvs.runcmd(["ip", "link", "show"])
     assert "Vxlan1" in stdout
     assert "Brvxlan1" in stdout
+
+def test_vxlanmgr_destructor_bulk_delete(dvs, env_setup):
+    """~VxlanMgr() bulk-deletes vxlan/bridge netdevs via IFLA_GROUP on SIGTERM"""
+
+    num_vnets = 50
+    vxlan_group = 0x534F4E01  # matches VXLAN_MGR_NETLINK_GROUP
+    cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
+
+    vnet_names = [f"Vnet_{i}" for i in range(num_vnets)]
+    for i, name in enumerate(vnet_names):
+        create_entry_tbl(
+            cfg_db,
+            "VNET", '|', name,
+            [
+                ("vxlan_tunnel", "tunnel1"),
+                ("vni", str(2000 + i)),
+            ],
+        )
+
+    def _count_group100():
+        _, out = dvs.runcmd(['sh', '-c',
+            f"ip -d link show | grep -c 'group {vxlan_group} ' || true"])
+        return int(out.strip()) if out.strip() else 0
+
+    # Each VNET produces a Vxlan + Brvxlan; +1 pair from env_setup tunnel1
+    expected_group100 = 2 * (num_vnets + 1)
+
+    wait_for_result(
+        lambda: (_count_group100() >= expected_group100, _count_group100()),
+        polling_config=PollingConfig(polling_interval=1, timeout=60, strict=True),
+        failure_message=f"vxlanmgrd did not create {expected_group100} group-100 netdevs",
+    )
+
+    # SIGTERM triggers ~VxlanMgr() bulk delete
+    dvs.runcmd(['sh', '-c', "supervisorctl stop vxlanmgrd"])
+
+    def _check_devices_gone():
+        remaining = _count_group100()
+        return (remaining == 0, remaining)
+
+    try:
+        wait_for_result(
+            _check_devices_gone,
+            polling_config=PollingConfig(polling_interval=1, timeout=15, strict=True),
+            failure_message="~VxlanMgr() did not bulk-delete group-100 devices on SIGTERM",
+        )
+    finally:
+        for name in vnet_names:
+            delete_entry_tbl(cfg_db, "VNET", name)
+        dvs.runcmd(['sh', '-c', "supervisorctl start vxlanmgrd"])
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
…FLA_GROUP

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

- Added graceful SIGTERM handling to vxlanmgrd and vrfmgrd so the manager objects are destroyed on config reload instead of being killed mid-flight.
- Tagged every VXLAN/bridge and VRF netdev created by these managers with a distinctive IFLA_GROUP value (one per manager).
- On destruction, issue a single grouped ip link delete group <id> type <vxlan|bridge|vrf> per device class to remove all owned netdevs in one netlink transaction.
- Scoped the bulk delete by link type so unrelated devices that may share a group id are never touched. 

**Why I did it**

- At scale (hundreds of VNETs/VRFs), config reload was slow because cleanup deleted netdevs one-by-one, each incurring its own RTNL round-trip and synchronize_net().
- A single grouped delete collapses the work into one kernel pass, giving deterministic, near-constant teardown time regardless of count.

**How I verified it**

- New DVS tests create a large batch of VXLAN tunnels / VRFs, send SIGTERM to the respective daemon, and assert that zero netdevs carrying the manager's group id remain.

**Details if related**
