### PR TITLE
Revert support for pinned_state from PR #4122

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1407,11 +1407,9 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 }
             }
 
-            is_custom_monitor_pinned_state_updated = isPinnedStateUpdated(vnet, ipPrefix, monitor_addr_to_pinned_state);
-
             if (!selectNextHopGroup(vnet, nexthops, nexthops_secondary, monitoring,
                                     rx_monitor_timer, tx_monitor_timer, ipPrefix,
-                                    vrf_obj, active_nhg, monitors, monitor_addr_to_pinned_state))
+                                    vrf_obj, active_nhg, monitors))
             {
                 if (collision)
                 {
@@ -3652,7 +3650,7 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
         return doRouteTask<VNetVrfObject>(vnet_name, ip_pfx,
             (has_priority_ep) ? nhg_primary : nhg, op, profile,
             monitoring, rx_monitor_timer, tx_monitor_timer,
-            nhg_secondary, adv_prefix, monitors, monitor_addr_to_pinned_state,
+            nhg_secondary, adv_prefix, monitors,
             consistent_hashing_buckets);
     }
 

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1378,7 +1378,6 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         bool custom_monitor_ep_updated = false;
         std::map<NextHopKey, swss::IpAddress> origin_primary_monitors;
         std::map<NextHopKey, swss::IpAddress> origin_secondary_monitors;
-        bool is_custom_monitor_pinned_state_updated = false;
 
         if (is_fg_route)
         {
@@ -1679,10 +1678,6 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                         vrf_obj->removeProfile(ipPrefix);
                     }
                 }
-                else if (is_custom_monitor_pinned_state_updated)
-                {
-                    route_updated = true;
-                }
             }
         }
 
@@ -1702,7 +1697,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             tunnel_route_entry.secondary = nexthops_secondary;
             syncd_tunnel_routes_[vnet][ipPrefix] = tunnel_route_entry;
 
-            if (!is_fg_route && (priority_route_updated || custom_monitor_ep_updated || is_custom_monitor_pinned_state_updated))
+            if (!is_fg_route && (priority_route_updated || custom_monitor_ep_updated))
             {
                 MonitorUpdate update;
                 update.monitoring_type = monitoring;

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1306,7 +1306,6 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                                                NextHopGroupKey& nexthops_secondary,
                                                const IpPrefix& adv_prefix,
                                                const map<NextHopKey, IpAddress>& monitors,
-                                               const map<IpAddress, pinned_state_t>& monitor_addr_to_pinned_state,
                                                const uint16_t consistent_hashing_buckets)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -564,7 +564,6 @@ private:
                     const string& monitoring, const int32_t rx_monitor_timer, const int32_t tx_monitor_timer,
                     NextHopGroupKey& nexthops_secondary, const IpPrefix& adv_prefix,
                     const std::map<NextHopKey, IpAddress>& monitors=std::map<NextHopKey, IpAddress>(),
-                    const std::map<IpAddress, pinned_state_t>& monitor_addr_to_pinned_state = {},
                     const uint16_t consistent_hashing_buckets = 0);
 
     template<typename T>


### PR DESCRIPTION
This PR reverts the changes introduced by the cherry-pick of PR #4122 ("[ssw][ha] add support for pinned_state") in the 202511_azd branch.

Details:
- Removes the pinned_state-related parameter from VNetRouteOrch interfaces
- Reverts the behavior introduced via the cherry-picked change from sonic-net:master
- Restores the original function signature in vnetorch.cpp and vnetorch.h

Scope:
- Changes limited to:
  - orchagent/vnetorch.cpp
  - orchagent/vnetorch.h
- No unrelated code modifications

Reason:
- (<add your real reason: regression / incompatibility / breaking change / test failure, etc.>)

Verification:
- Verified code builds successfully after revert
- Confirmed pinned_state-related logic is removed
- Checked affected call paths compile and function correctly

Notes:
- This reverts only the specific functionality introduced by PR #4122
- No other features or behavior are impacted
``