### PR TITLE
Fine Grained ECMP for Vnet Tunnel Routes

### DIFF
--- a/orchagent/fgnhgorch.cpp
+++ b/orchagent/fgnhgorch.cpp
@@ -6,6 +6,8 @@
 #include "logger.h"
 #include "swssnet.h"
 #include "crmorch.h"
+#include "directory.h"
+#include "vnetorch.h"
 #include <array>
 #include <algorithm>
 
@@ -15,9 +17,11 @@
 extern sai_object_id_t gVirtualRouterId;
 extern sai_object_id_t gSwitchId;
 
+extern sai_switch_api_t*            sai_switch_api;
 extern sai_next_hop_group_api_t*    sai_next_hop_group_api;
 extern sai_route_api_t*             sai_route_api;
 
+extern Directory<Orch*> gDirectory;
 extern RouteOrch *gRouteOrch;
 extern CrmOrch *gCrmOrch;
 extern PortsOrch *gPortsOrch;
@@ -213,22 +217,30 @@ void FgNhgOrch::calculateBankHashBucketStartIndices(FgNhgEntry *fgNhgEntry)
 }
 
 
-void FgNhgOrch::setStateDbRouteEntry(const IpPrefix &ipPrefix, uint32_t index, NextHopKey nextHop)
+string FgNhgOrch::getWarmRebootStateDbKey(const string &vnet, const IpPrefix &ipPrefix)
+{
+    if (vnet.empty())
+    {
+        return ipPrefix.to_string();
+    }
+    return vnet + state_db_key_delimiter + ipPrefix.to_string();
+}
+
+void FgNhgOrch::setStateDbRouteEntry(const string &key, uint32_t index, NextHopKey nextHop)
 {
     SWSS_LOG_ENTER();
 
-    string key = ipPrefix.to_string();
     string field = std::to_string(index);
     string value = nextHop.to_string();
 
     m_stateWarmRestartRouteTable.hset(key, field, value);
 
-    SWSS_LOG_INFO("Set state db entry for ip prefix %s next hop %s with index %d",
+    SWSS_LOG_INFO("Set state db entry for key %s next hop %s with index %d",
                   key.c_str(), value.c_str(), index);
 }
 
 bool FgNhgOrch::writeHashBucketChange(FGNextHopGroupEntry *syncd_fg_route_entry, HashBucketIdx index, sai_object_id_t nh_oid,
-        const IpPrefix &ipPrefix, NextHopKey nextHop)
+        const string &key, NextHopKey nextHop)
 {
     SWSS_LOG_ENTER();
 
@@ -249,7 +261,59 @@ bool FgNhgOrch::writeHashBucketChange(FGNextHopGroupEntry *syncd_fg_route_entry,
         }
     }
 
-    setStateDbRouteEntry(ipPrefix, index, nextHop);
+    setStateDbRouteEntry(key, index, nextHop);
+    return true;
+}
+
+bool FgNhgOrch::getMaxEcmpMemberCount(uint32_t &maxEcmpMembers)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t switch_attr;
+    switch_attr.id = SAI_SWITCH_ATTR_MAX_ECMP_MEMBER_COUNT;
+    switch_attr.value.u32 = 0;
+
+    sai_status_t status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &switch_attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Failed to query SAI_SWITCH_ATTR_MAX_ECMP_MEMBER_COUNT, rv:%d", status);
+        return false;
+    }
+
+    maxEcmpMembers = switch_attr.value.u32;
+    return true;
+}
+
+bool FgNhgOrch::getEffectiveFgNhgMemberCapacity(uint32_t configuredBucketSize, uint32_t &memberCapacity)
+{
+    SWSS_LOG_ENTER();
+
+    memberCapacity = configuredBucketSize;
+
+    uint32_t hw_max_ecmp_members = 0;
+    if (!getMaxEcmpMemberCount(hw_max_ecmp_members))
+    {
+        return false;
+    }
+
+    memberCapacity = min(memberCapacity, hw_max_ecmp_members);
+    return true;
+}
+
+bool FgNhgOrch::validateFgNhgMemberCount(size_t memberCount, uint32_t configuredBucketSize, const string &logKey)
+{
+    SWSS_LOG_ENTER();
+
+    uint32_t member_capacity = 0;
+    getEffectiveFgNhgMemberCapacity(configuredBucketSize, member_capacity);
+
+    if (memberCount > member_capacity)
+    {
+        SWSS_LOG_ERROR("Number of next-hops %zu exceeds effective FG NHG member capacity %u for %s",
+                       memberCount, member_capacity, logKey.c_str());
+        return false;
+    }
+
     return true;
 }
 
@@ -261,6 +325,30 @@ bool FgNhgOrch::createFineGrainedNextHopGroup(FGNextHopGroupEntry &syncd_fg_rout
     string platform = getenv("platform") ? getenv("platform") : "";
     sai_attribute_t nhg_attr;
     vector<sai_attribute_t> nhg_attrs;
+
+    /* Query hardware maximum ECMP member count */
+    uint32_t effective_member_capacity = 0;
+    bool hw_limit_available = getEffectiveFgNhgMemberCapacity(fgNhgEntry->configured_bucket_size,
+                                                              effective_member_capacity);
+    
+    if (!hw_limit_available)
+    {
+        SWSS_LOG_WARN("Unable to verify hardware ECMP member limit. Proceeding with configured bucket size %d",
+                      fgNhgEntry->configured_bucket_size);
+    }
+    else
+    {
+        SWSS_LOG_INFO("Effective FG NHG member capacity: %d, Configured bucket size: %d",
+                      effective_member_capacity, fgNhgEntry->configured_bucket_size);
+        
+        /* If configured bucket size exceeds hardware maximum, adjust it */
+        if (fgNhgEntry->configured_bucket_size > effective_member_capacity)
+        {
+            SWSS_LOG_WARN("Configured bucket size %d exceeds effective FG NHG member capacity %d. Adjusting bucket size.",
+                          fgNhgEntry->configured_bucket_size, effective_member_capacity);
+            fgNhgEntry->configured_bucket_size = effective_member_capacity;
+        }
+    }
 
     nhg_attr.id = SAI_NEXT_HOP_GROUP_ATTR_TYPE;
     nhg_attr.value.s32 = SAI_NEXT_HOP_GROUP_TYPE_FINE_GRAIN_ECMP;
@@ -440,6 +528,10 @@ bool FgNhgOrch::validNextHopInNextHopGroup(const NextHopKey& nexthop)
                     nhs_to_add.push_back(nexthop);
             nhopgroup_members_set[nexthop] = m_neighOrch->getNextHopId(nexthop);
 
+            string vnet;
+            getVnetNameByVrfId(route_tables.first, vnet);
+            string key = getWarmRebootStateDbKey(vnet, route_table.first);
+
             if (syncd_fg_route_entry->points_to_rif)
             {
                 // RIF route is now neigh resolved: create Fine Grained ECMP
@@ -448,7 +540,7 @@ bool FgNhgOrch::validNextHopInNextHopGroup(const NextHopKey& nexthop)
                     return false;
                 }
 
-                if (!setNewNhgMembers(*syncd_fg_route_entry, fgNhgEntry, bank_member_changes, nhopgroup_members_set, route_table.first))
+                if (!setNewNhgMembers(*syncd_fg_route_entry, fgNhgEntry, bank_member_changes, nhopgroup_members_set, key))
                 {
                     return false;
                 }
@@ -468,7 +560,7 @@ bool FgNhgOrch::validNextHopInNextHopGroup(const NextHopKey& nexthop)
                 }
 
                 if (!computeAndSetHashBucketChanges(syncd_fg_route_entry, fgNhgEntry,
-                        bank_member_changes, nhopgroup_members_set, route_table.first))
+                        bank_member_changes, nhopgroup_members_set, key, route_table.first))
                 {
                     SWSS_LOG_ERROR("Failed to set fine grained next hop %s",
                         nexthop.to_string().c_str());
@@ -546,8 +638,12 @@ bool FgNhgOrch::invalidNextHopInNextHopGroup(const NextHopKey& nexthop)
             bank_member_changes[fgNhgEntry->next_hops[nexthop.ip_address].bank].
                     nhs_to_del.push_back(nexthop);
 
+            string vnet;
+            getVnetNameByVrfId(route_tables.first, vnet);
+            string key = getWarmRebootStateDbKey(vnet, route_table.first);
+
             if (!computeAndSetHashBucketChanges(syncd_fg_route_entry, fgNhgEntry,
-                    bank_member_changes, nhopgroup_members_set, route_table.first))
+                    bank_member_changes, nhopgroup_members_set, key, route_table.first))
             {
                 SWSS_LOG_ERROR("Failed to set fine grained next hop %s",
                     nexthop.to_string().c_str());
@@ -577,7 +673,7 @@ bool FgNhgOrch::invalidNextHopInNextHopGroup(const NextHopKey& nexthop)
  */
 bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
         uint32_t syncd_bank, BankMemberChanges bank_member_change,
-        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix &ipPrefix)
+        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key)
 {
     SWSS_LOG_ENTER();
 
@@ -595,7 +691,7 @@ bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
         {
             if (!writeHashBucketChange(syncd_fg_route_entry, hash_buckets->at(i),
                         nhopgroup_members_set[bank_member_change.nhs_to_add[add_idx]],
-                        ipPrefix, bank_member_change.nhs_to_add[add_idx]))
+                        key, bank_member_change.nhs_to_add[add_idx]))
             {
                 return false;
             }
@@ -643,7 +739,7 @@ bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
                     {
                         // this can neven happen
                         SWSS_LOG_ERROR("%s Unexpected no more active NHs before adding the %zu buckets, exp_bucket_size(%d)",
-                                       ipPrefix.to_string().c_str(),
+                                       key.c_str(),
                                        hash_buckets->size(), exp_bucket_size);
                         return false;
                     }
@@ -654,7 +750,19 @@ bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
                  * other available nhs, but for cases where # hash buckets is not
                  * divisible by # of nhs, simple round robin can make the hash bucket
                  * distribution non-ideal, thereby nhs can attract unequal traffic */
-                if (bank_fgnhg_map->at(*it).size() == exp_bucket_size)
+                if (bank_fgnhg_map->at(*it).size() > exp_bucket_size)
+                {
+                    // NH already has more than its fair share from a prior redistribution 
+                    if (num_nhs_with_one_more > 0)
+                    {
+                        num_nhs_with_one_more--;
+                    }
+                    SWSS_LOG_INFO("%s already has %zu buckets (> %d), skip assigning more, bkt_idx(%d)",
+                                  (*it).to_string().c_str(), bank_fgnhg_map->at(*it).size(),
+                                  exp_bucket_size, bkt_idx);
+                    remove_nh = true;
+                }
+                else if (bank_fgnhg_map->at(*it).size() == exp_bucket_size)
                 {
                     if (num_nhs_with_one_more == 0)
                     {
@@ -682,7 +790,7 @@ bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
                 if (move_bkt)
                 {
                     if (!writeHashBucketChange(syncd_fg_route_entry, hash_buckets->at(bkt_idx),
-                                               nhopgroup_members_set[*it], ipPrefix, *it))
+                                               nhopgroup_members_set[*it], key, *it))
                     {
                         return false;
                     }
@@ -794,7 +902,7 @@ bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
                     HashBucketIdx last_elem = map_entry->at((*map_entry).size() - 1);
                     if (!writeHashBucketChange(syncd_fg_route_entry, last_elem,
                                                nhopgroup_members_set[bank_member_change.nhs_to_add[add_idx]],
-                                               ipPrefix, bank_member_change.nhs_to_add[add_idx]))
+                                               key, bank_member_change.nhs_to_add[add_idx]))
                     {
                         return false;
                     }
@@ -822,7 +930,7 @@ bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
 
 bool FgNhgOrch::setInactiveBankToNextAvailableActiveBank(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
         uint32_t bank, std::vector<BankMemberChanges> bank_member_changes,
-        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix &ipPrefix)
+        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key, const IpPrefix &ipPrefix)
 {
     SWSS_LOG_ENTER();
 
@@ -848,7 +956,7 @@ bool FgNhgOrch::setInactiveBankToNextAvailableActiveBank(FGNextHopGroupEntry *sy
                          active_nhs[i % bank_member_changes[new_bank_idx].active_nhs.size()];
 
                 if (!writeHashBucketChange(syncd_fg_route_entry, i,
-                    nhopgroup_members_set[bank_nh_memb],ipPrefix, bank_nh_memb ))
+                    nhopgroup_members_set[bank_nh_memb], key, bank_nh_memb ))
                 {
                     return false;
                 }
@@ -894,7 +1002,7 @@ bool FgNhgOrch::setInactiveBankToNextAvailableActiveBank(FGNextHopGroupEntry *sy
             syncd_fg_route_entry->next_hop_group_id = rif_next_hop_id;
 
             // remove state_db entry
-            m_stateWarmRestartRouteTable.del(ipPrefix.to_string());
+            m_stateWarmRestartRouteTable.del(key);
             // Clear data structures
             syncd_fg_route_entry->syncd_fgnhg_map.clear();
             syncd_fg_route_entry->active_nexthops.clear();
@@ -920,7 +1028,7 @@ bool FgNhgOrch::setInactiveBankToNextAvailableActiveBank(FGNextHopGroupEntry *sy
  */
 bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
         uint32_t bank,std::vector<BankMemberChanges> &bank_member_changes,
-        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix &ipPrefix)
+        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key, const IpPrefix &ipPrefix)
 {
     SWSS_LOG_ENTER();
 
@@ -936,7 +1044,7 @@ bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_r
                 nhs_to_add[i % bank_member_changes[bank].nhs_to_add.size()];
 
             if (!writeHashBucketChange(syncd_fg_route_entry, i,
-                  nhopgroup_members_set[bank_nh_memb], ipPrefix, bank_nh_memb))
+                  nhopgroup_members_set[bank_nh_memb], key, bank_nh_memb))
             {
                 return false;
             }
@@ -954,7 +1062,7 @@ bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_r
         /* Previously active bank now transitions to inactive */
         SWSS_LOG_INFO("Previously active bank now transitions to inactive bank %u", bank);
         if (!setInactiveBankToNextAvailableActiveBank(syncd_fg_route_entry, fgNhgEntry,
-                    bank, bank_member_changes, nhopgroup_members_set, ipPrefix))
+                    bank, bank_member_changes, nhopgroup_members_set, key, ipPrefix))
         {
             SWSS_LOG_INFO("Failed to map to active_bank and set nh in SAI");
             return false;
@@ -976,7 +1084,7 @@ bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_r
         if (bank_member_changes[active_bank].active_nhs.size() == 0)
         {
             if (!setInactiveBankToNextAvailableActiveBank(syncd_fg_route_entry, fgNhgEntry,
-                        bank, bank_member_changes, nhopgroup_members_set, ipPrefix))
+                        bank, bank_member_changes, nhopgroup_members_set, key, ipPrefix))
             {
                 return false;
             }
@@ -984,7 +1092,7 @@ bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_r
         else
         {
             if (!setActiveBankHashBucketChanges(syncd_fg_route_entry, fgNhgEntry,
-                bank, bank_member_changes[active_bank], nhopgroup_members_set, ipPrefix))
+                bank, bank_member_changes[active_bank], nhopgroup_members_set, key))
             {
                 return false;
             }
@@ -997,7 +1105,7 @@ bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_r
 bool FgNhgOrch::computeAndSetHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry,
         FgNhgEntry *fgNhgEntry, std::vector<BankMemberChanges> &bank_member_changes,
         std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set,
-        const IpPrefix &ipPrefix)
+        const string &key, const IpPrefix &ipPrefix)
 {
     SWSS_LOG_ENTER();
 
@@ -1014,7 +1122,7 @@ bool FgNhgOrch::computeAndSetHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
              * Route this to fn which deals with active banks
              */
             if (!setActiveBankHashBucketChanges(syncd_fg_route_entry, fgNhgEntry,
-                        bank_idx, bank_member_changes[bank_idx], nhopgroup_members_set, ipPrefix))
+                        bank_idx, bank_member_changes[bank_idx], nhopgroup_members_set, key))
             {
                 return false;
             }
@@ -1022,7 +1130,7 @@ bool FgNhgOrch::computeAndSetHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
         else
         {
             if (!setInactiveBankHashBucketChanges(syncd_fg_route_entry, fgNhgEntry,
-                        bank_idx, bank_member_changes, nhopgroup_members_set, ipPrefix))
+                        bank_idx, bank_member_changes, nhopgroup_members_set, key, ipPrefix))
             {
                 return false;
             }
@@ -1035,7 +1143,7 @@ bool FgNhgOrch::computeAndSetHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
 
 bool FgNhgOrch::setNewNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
         std::vector<BankMemberChanges> &bank_member_changes, std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set,
-        const IpPrefix &ipPrefix)
+        const string &key)
 {
     SWSS_LOG_ENTER();
 
@@ -1074,7 +1182,7 @@ bool FgNhgOrch::setNewNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, FgNh
     for (auto active_bank : active_banks)
     {
         syncd_fg_route_entry.inactive_to_active_map[active_bank] = active_bank;
-        if (!sprayBankNhgMembers(syncd_fg_route_entry, ipPrefix,
+        if (!sprayBankNhgMembers(syncd_fg_route_entry, key,
                 fgNhgEntry->hash_bucket_indices[active_bank], fgNhgEntry,
                 active_bank, bank_member_changes[active_bank],
                 nhopgroup_members_set))
@@ -1089,18 +1197,18 @@ bool FgNhgOrch::setNewNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, FgNh
         auto active_bank = active_banks[i % active_banks.size()];
         syncd_fg_route_entry.inactive_to_active_map[inactive_banks[i]] =
             active_bank;
-        if(!sprayBankNhgMembers(syncd_fg_route_entry, ipPrefix,
+        if(!sprayBankNhgMembers(syncd_fg_route_entry, key,
                 fgNhgEntry->hash_bucket_indices[inactive_banks[i]], fgNhgEntry,
                 inactive_banks[i], bank_member_changes[active_bank],
                 nhopgroup_members_set))
         {
             return false;
         }
-        SWSS_LOG_NOTICE("Bank# %d of FG next-hops is down for prefix %s",
-                inactive_banks[i], ipPrefix.to_string().c_str());
+        SWSS_LOG_NOTICE("Bank# %d of FG next-hops is down for key %s",
+                inactive_banks[i], key.c_str());
     }
 
-    auto nexthopsMap = m_recoveryMap.find(ipPrefix.to_string());
+    auto nexthopsMap = m_recoveryMap.find(key);
     if (nexthopsMap != m_recoveryMap.end()) {
         m_recoveryMap.erase(nexthopsMap);
     }
@@ -1110,14 +1218,13 @@ bool FgNhgOrch::setNewNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, FgNh
     return true;
 }
 
-bool FgNhgOrch::sprayBankNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, const IpPrefix &ipPrefix,
-        BankIndexRange hash_idx_range, FgNhgEntry *fgNhgEntry,
+bool FgNhgOrch::sprayBankNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, const string &key, BankIndexRange hash_idx_range, FgNhgEntry *fgNhgEntry,
         uint32_t bank, BankMemberChanges &bank_member_change,
         std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set)
 {
     sai_status_t status;
     bool isWarmReboot = false;
-    auto nexthopsMap = m_recoveryMap.find(ipPrefix.to_string());
+    auto nexthopsMap = m_recoveryMap.find(key);
 
     SWSS_LOG_ENTER();
 
@@ -1139,9 +1246,10 @@ bool FgNhgOrch::sprayBankNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, c
             nh_memb_key = nexthopsMap->second[bucket_idx];
             SWSS_LOG_INFO("Recovering nexthop %s with bucket_idx %d", nh_memb_key.ip_address.to_string().c_str(), bucket_idx);
             // case nhps in bank are all down
-            if (fgNhgEntry->next_hops[nh_memb_key.ip_address].bank != bank)
+            auto ip_bank = fgNhgEntry->match_mode == FGMatchMode::PREFIX_BASED ? 0 : fgNhgEntry->next_hops[nh_memb_key.ip_address].bank;
+            if (ip_bank != bank)
             {
-                syncd_fg_route_entry.inactive_to_active_map[bank] = fgNhgEntry->next_hops[nh_memb_key.ip_address].bank;
+                syncd_fg_route_entry.inactive_to_active_map[bank] = ip_bank;
             }
         }
         else
@@ -1187,7 +1295,7 @@ bool FgNhgOrch::sprayBankNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, c
             }
         }
 
-        setStateDbRouteEntry(ipPrefix, bucket_idx, nh_memb_key);
+        setStateDbRouteEntry(key, bucket_idx, nh_memb_key);
         syncd_fg_route_entry.syncd_fgnhg_map[bank][nh_memb_key].push_back(bucket_idx);
         syncd_fg_route_entry.active_nexthops.insert(nh_memb_key);
         syncd_fg_route_entry.nhopgroup_members[bucket_idx] = next_hop_group_member_id;
@@ -1204,8 +1312,8 @@ bool FgNhgOrch::isRouteFineGrained(sai_object_id_t vrf_id, const IpPrefix &ipPre
 
     if (!isFineGrainedConfigured || (vrf_id != gVirtualRouterId))
     {
-        SWSS_LOG_DEBUG("Route %s:%s vrf %" PRIx64 " default_vrf %" PRIx64 " NOT fine grained ECMP",
-                        ipPrefix.to_string().c_str(), nextHops.to_string().c_str(), vrf_id, gVirtualRouterId);
+        SWSS_LOG_DEBUG("Route %s:%s vrf %" PRIx64 " NOT fine grained ECMP",
+                        ipPrefix.to_string().c_str(), nextHops.to_string().c_str(), vrf_id);
         return false;
     }
 
@@ -1253,7 +1361,7 @@ bool FgNhgOrch::isRouteFineGrained(sai_object_id_t vrf_id, const IpPrefix &ipPre
 
 bool FgNhgOrch::syncdContainsFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix)
 {
-    if (!isFineGrainedConfigured || (vrf_id != gVirtualRouterId))
+    if (!isFineGrainedConfigured)
     {
         return false;
     }
@@ -1460,6 +1568,17 @@ bool FgNhgOrch::setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const
         nhopgroup_members_set[nhk] = nhid;
     }
 
+    std::string vnet;
+    getVnetNameByVrfId(vrf_id, vnet);
+    string key = getWarmRebootStateDbKey(vnet, ipPrefix);
+
+    /* Defensive sanity check before SAI programming. Invalid config should be rejected earlier. */
+    if (!validateFgNhgMemberCount(nhopgroup_members_set.size(), fgNhgEntry->configured_bucket_size,
+                                  ipPrefix.to_string()))
+    {
+        return false;
+    }
+
     if (syncd_fg_route_entry_it != m_syncdFGRouteTables.at(vrf_id).end())
     {
         /* Route exists and nh was associated in the past */
@@ -1475,7 +1594,7 @@ bool FgNhgOrch::setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const
                     return false;
                 }
 
-                if (!setNewNhgMembers(*syncd_fg_route_entry, fgNhgEntry, bank_member_changes, nhopgroup_members_set, ipPrefix))
+                if (!setNewNhgMembers(*syncd_fg_route_entry, fgNhgEntry, bank_member_changes, nhopgroup_members_set, key))
                 {
                     return false;
                 }
@@ -1499,7 +1618,7 @@ bool FgNhgOrch::setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const
             }
 
             if (!computeAndSetHashBucketChanges(syncd_fg_route_entry, fgNhgEntry, bank_member_changes,
-                    nhopgroup_members_set, ipPrefix))
+                    nhopgroup_members_set, key, ipPrefix))
             {
                 return false;
             }
@@ -1517,7 +1636,7 @@ bool FgNhgOrch::setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const
                 return false;
             }
 
-            if (!setNewNhgMembers(syncd_fg_route_entry, fgNhgEntry, bank_member_changes, nhopgroup_members_set, ipPrefix))
+            if (!setNewNhgMembers(syncd_fg_route_entry, fgNhgEntry, bank_member_changes, nhopgroup_members_set, key))
             {
                 return false;
             }
@@ -1561,6 +1680,143 @@ bool FgNhgOrch::setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const
     return true;
 }
 
+bool FgNhgOrch::setFgNhgTunnel(sai_object_id_t vrf_id, const IpPrefix &ipPrefix,
+                        map<NextHopKey, sai_object_id_t>& nhopgroup_members_set, NextHopGroupKey& nextHops, uint16_t consistent_hashing_buckets,
+                        sai_object_id_t &next_hop_id, bool &isNextHopIdChanged)
+{
+    SWSS_LOG_ENTER();
+
+    /* default isNextHopIdChanged to false so that sai route is unaffected
+     * when we return early with success */
+    isNextHopIdChanged = false;
+
+    FGMatchMode match_mode = FGMatchMode::PREFIX_BASED;
+    uint32_t max_next_hops = consistent_hashing_buckets;
+    uint32_t bucket_size = consistent_hashing_buckets;
+    std::string fg_nhg_name = "FG_NHG_" + std::to_string(vrf_id) + "_" + ipPrefix.to_string();
+
+    std::string vnet;
+    getVnetNameByVrfId(vrf_id, vnet);
+    string key = getWarmRebootStateDbKey(vnet, ipPrefix);
+
+    if (bucket_size < 1)
+    {
+        SWSS_LOG_ERROR("Received bucket_size which is < 1 for key %s",
+                fg_nhg_name.c_str());
+        return true;
+    }
+
+    if (!validateFgNhgMemberCount(nhopgroup_members_set.size(), bucket_size, fg_nhg_name))
+    {
+        return false;
+    }
+
+    FgNhgEntry fgNhgEntry;
+    fgNhgEntry.configured_bucket_size = bucket_size;
+    fgNhgEntry.fg_nhg_name = fg_nhg_name;
+    fgNhgEntry.match_mode = match_mode;
+    fgNhgEntry.max_next_hops = max_next_hops;
+    SWSS_LOG_NOTICE("Added new FG_NHG entry %s with bucket_size %d, match_mode: %'" PRIu8,
+            fg_nhg_name.c_str(), bucket_size, match_mode);
+    isFineGrainedConfigured = true;
+    
+    if (m_FgNhgs.find(fg_nhg_name) == m_FgNhgs.end())
+    {
+        m_FgNhgs[fg_nhg_name] = fgNhgEntry;
+        m_FgNhgs[fg_nhg_name].prefixes.push_back(ipPrefix);
+    }
+
+    if (m_syncdFGRouteTables.find(vrf_id) != m_syncdFGRouteTables.end() &&
+        m_syncdFGRouteTables.at(vrf_id).find(ipPrefix) != m_syncdFGRouteTables.at(vrf_id).end() &&
+        m_syncdFGRouteTables.at(vrf_id).at(ipPrefix).nhg_key == nextHops)
+    {
+        return true;
+    }
+
+    if (m_syncdFGRouteTables.find(vrf_id) == m_syncdFGRouteTables.end())
+    {
+        m_syncdFGRouteTables.emplace(vrf_id, FGRouteTable());
+        m_vrfOrch->increaseVrfRefCount(vrf_id);
+    }
+
+    auto syncd_fg_route_entry_it = m_syncdFGRouteTables.at(vrf_id).find(ipPrefix);
+    bool next_hop_to_add = false;
+
+    /* Default init with # of banks */
+    std::vector<BankMemberChanges> bank_member_changes(1, BankMemberChanges()); // prefix_based match_mode supports single bank
+
+    /* initialize m_FgNhgs[fg_nhg_name].next_hops with the list of IP addresses in nextHops
+    and add the corresponding next_hop_id to next_hop_ids. */
+    for (const auto& member : nhopgroup_members_set)
+    {
+        const NextHopKey& nhk = member.first;
+
+        if (syncd_fg_route_entry_it == m_syncdFGRouteTables.at(vrf_id).end())
+        {
+            bank_member_changes[0].nhs_to_add.push_back(nhk);
+            next_hop_to_add = true;
+        }
+        else
+        {
+            FGNextHopGroupEntry *syncd_fg_route_entry = &(syncd_fg_route_entry_it->second);
+            if (syncd_fg_route_entry->active_nexthops.find(nhk) ==
+                syncd_fg_route_entry->active_nexthops.end())
+            {
+                bank_member_changes[0].nhs_to_add.push_back(nhk);
+                next_hop_to_add = true;
+            }
+        }
+    }
+
+    if (syncd_fg_route_entry_it != m_syncdFGRouteTables.at(vrf_id).end())
+    {
+        /* Route exists and nh was associated in the past */
+        FGNextHopGroupEntry *syncd_fg_route_entry = &(syncd_fg_route_entry_it->second);
+
+        /* Update FG ECMP group in SAI */
+        for (auto nhk : syncd_fg_route_entry->active_nexthops)
+        {
+            if (nhopgroup_members_set.find(nhk) == nhopgroup_members_set.end())
+            {
+                bank_member_changes[0].nhs_to_del.push_back(nhk);
+            }
+            else
+            {
+                bank_member_changes[0].active_nhs.push_back(nhk);
+            }
+        }
+
+        if (!computeAndSetHashBucketChanges(syncd_fg_route_entry, &m_FgNhgs[fg_nhg_name], bank_member_changes,
+                nhopgroup_members_set, key, ipPrefix))
+        {
+            return false;
+        }
+    }
+    else
+    {
+        /* New route + nhg addition */
+        isNextHopIdChanged = true;
+        FGNextHopGroupEntry syncd_fg_route_entry;
+        if (next_hop_to_add)
+        {
+            if (!createFineGrainedNextHopGroup(syncd_fg_route_entry, &m_FgNhgs[fg_nhg_name], nextHops))
+            {
+                return false;
+            }
+
+            if (!setNewNhgMembers(syncd_fg_route_entry, &m_FgNhgs[fg_nhg_name], bank_member_changes, nhopgroup_members_set, key))
+            {
+                return false;
+            }
+        }
+        m_syncdFGRouteTables[vrf_id][ipPrefix] = syncd_fg_route_entry;
+    }
+
+    m_syncdFGRouteTables[vrf_id][ipPrefix].nhg_key = nextHops;
+    next_hop_id =  m_syncdFGRouteTables[vrf_id][ipPrefix].next_hop_group_id;
+
+    return true;
+}
 
 bool FgNhgOrch::removeFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix)
 {
@@ -1602,7 +1858,10 @@ bool FgNhgOrch::removeFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix)
         }
 
         // remove state_db entry
-        m_stateWarmRestartRouteTable.del(ipPrefix.to_string());
+        string vnet;
+        getVnetNameByVrfId(vrf_id, vnet);
+        string key = getWarmRebootStateDbKey(vnet, ipPrefix);
+        m_stateWarmRestartRouteTable.del(key);
     }
 
     it_route_table->second.erase(it_route);
@@ -1617,6 +1876,59 @@ bool FgNhgOrch::removeFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix)
     return true;
 }
 
+bool FgNhgOrch::removeFgNhgTunnel(sai_object_id_t vrf_id, const IpPrefix &ipPrefix)
+{
+    SWSS_LOG_ENTER();
+
+    if (!isFineGrainedConfigured)
+    {
+        return true;
+    }
+
+    auto it_route_table = m_syncdFGRouteTables.find(vrf_id);
+    if (it_route_table == m_syncdFGRouteTables.end())
+    {
+        SWSS_LOG_INFO("No route table found for %s, vrf_id 0x%" PRIx64,
+                ipPrefix.to_string().c_str(), vrf_id);
+        return true;
+    }
+
+    auto it_route = it_route_table->second.find(ipPrefix);
+    if (it_route == it_route_table->second.end())
+    {
+        SWSS_LOG_INFO("Failed to find route entry, vrf_id 0x%" PRIx64 ", prefix %s", vrf_id,
+                ipPrefix.to_string().c_str());
+        return true;
+    }
+
+    FGNextHopGroupEntry *syncd_fg_route_entry = &(it_route->second);
+    if (!removeFineGrainedNextHopGroup(syncd_fg_route_entry))
+    {
+        SWSS_LOG_ERROR("Failed to clean-up fine grained ECMP SAI group");
+        return false;
+    }
+
+    // remove state_db entry
+    string vnet;
+    getVnetNameByVrfId(vrf_id, vnet);
+    string key = getWarmRebootStateDbKey(vnet, ipPrefix);
+    m_stateWarmRestartRouteTable.del(key);
+
+    // remove from m_FgNhgs
+    std::string fg_nhg_name = "FG_NHG_" + std::to_string(vrf_id) + "_" + ipPrefix.to_string();
+    m_FgNhgs.erase(fg_nhg_name);
+
+    it_route_table->second.erase(it_route);
+    if (it_route_table->second.size() == 0)
+    {
+        m_syncdFGRouteTables.erase(vrf_id);
+        m_vrfOrch->decreaseVrfRefCount(vrf_id);
+    }
+    SWSS_LOG_NOTICE("All banks of FG next-hops are down for vrf_id 0x%" PRIx64 ", prefix %s", vrf_id,
+            ipPrefix.to_string().c_str());
+
+    return true;
+}
 
 vector<FieldValueTuple> FgNhgOrch::generateRouteTableFromNhgKey(NextHopGroupKey nhg)
 {
@@ -2161,4 +2473,17 @@ void FgNhgOrch::doTask(Consumer& consumer)
         }
     }
     return;
+}
+
+bool FgNhgOrch::getVnetNameByVrfId(sai_object_id_t vrf_id, std::string& vnet_name)
+{
+    auto *vnet_orch = gDirectory.get<VNetOrch*>();
+    assert(vnet_orch); 
+
+    if (!vnet_orch->getVnetNameByVrfId(vrf_id, vnet_name) && vrf_id == gVirtualRouterId)
+    {
+        vnet_name = "";
+        return false;
+    }
+    return true;
 }

--- a/orchagent/fgnhgorch.h
+++ b/orchagent/fgnhgorch.h
@@ -112,7 +112,9 @@ public:
     bool validNextHopInNextHopGroup(const NextHopKey&);
     bool invalidNextHopInNextHopGroup(const NextHopKey&);
     bool setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const NextHopGroupKey &nextHops, sai_object_id_t &next_hop_id, bool &isNextHopIdChanged);
+    bool setFgNhgTunnel(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, map<NextHopKey, sai_object_id_t>& nhopgroup_members_set, NextHopGroupKey& nextHops, uint16_t consistent_hashing_buckets, sai_object_id_t &next_hop_id, bool &isNextHopIdChanged);
     bool removeFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix);
+    bool removeFgNhgTunnel(sai_object_id_t vrf_id, const IpPrefix &ipPrefix);
 
     // warm reboot support
     bool bake() override;
@@ -142,28 +144,32 @@ private:
 
     bool setNewNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
                     std::vector<BankMemberChanges> &bank_member_changes,
-                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix&);
-    bool sprayBankNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, const IpPrefix &ipPrefix,
+                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key);
+    bool sprayBankNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, const string &key,
                     BankIndexRange hash_idx_range, FgNhgEntry *fgNhgEntry,
                     uint32_t bank, BankMemberChanges &bank_member_change,
                     std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set);
 
     bool computeAndSetHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry,
                     FgNhgEntry *fgNhgEntry, std::vector<BankMemberChanges> &bank_member_changes,
-                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix&);
+                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key, const IpPrefix&);
     bool setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
                     uint32_t syncd_bank, BankMemberChanges bank_member_changes,
-                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix&);
+                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key);
     bool setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
                     uint32_t bank,std::vector<BankMemberChanges> &bank_member_changes,
-                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix&);
+                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key, const IpPrefix&);
     bool setInactiveBankToNextAvailableActiveBank(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
                     uint32_t bank, std::vector<BankMemberChanges> bank_member_changes,
-                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix&);
+                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key, const IpPrefix&);
     void calculateBankHashBucketStartIndices(FgNhgEntry *fgNhgEntry);
-    void setStateDbRouteEntry(const IpPrefix&, uint32_t index, NextHopKey nextHop);
+    bool getMaxEcmpMemberCount(uint32_t &maxEcmpMembers);
+    bool getEffectiveFgNhgMemberCapacity(uint32_t configuredBucketSize, uint32_t &memberCapacity);
+    bool validateFgNhgMemberCount(size_t memberCount, uint32_t configuredBucketSize, const string &logKey);
+    string getWarmRebootStateDbKey(const string &vnet, const IpPrefix &ipPrefix);
+    void setStateDbRouteEntry(const string &key, uint32_t index, NextHopKey nextHop);
     bool writeHashBucketChange(FGNextHopGroupEntry *syncd_fg_route_entry, uint32_t index, sai_object_id_t nh_oid,
-                    const IpPrefix &ipPrefix, NextHopKey nextHop);
+                     const string &key, NextHopKey nextHop);
     bool modifyRoutesNextHopId(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, sai_object_id_t next_hop_id);
     bool createFineGrainedNextHopGroup(FGNextHopGroupEntry &syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
                     const NextHopGroupKey &nextHops);
@@ -171,6 +177,7 @@ private:
     vector<FieldValueTuple> generateRouteTableFromNhgKey(NextHopGroupKey nhg);
     void cleanupIpInLinkToIpMap(const string &link, const IpAddress &ip, FgNhgEntry &fgNhg_entry);
 
+    bool getVnetNameByVrfId(sai_object_id_t vrf_id, std::string& vnet_name);
     bool doTaskFgNhg(const KeyOpFieldsValuesTuple&);
     bool doTaskFgNhgPrefix(const KeyOpFieldsValuesTuple&);
     bool doTaskFgNhgMember(const KeyOpFieldsValuesTuple&);

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -46,6 +46,7 @@ extern MacAddress gVxlanMacAddress;
 extern BfdOrch *gBfdOrch;
 extern SwitchOrch *gSwitchOrch;
 extern TunnelDecapOrch *gTunneldecapOrch;
+extern FgNhgOrch *gFgNhgOrch;
 /*
  * VRF Modeling and VNetVrf class definitions
  */
@@ -323,6 +324,23 @@ sai_object_id_t VNetVrfObject::getTunnelNextHop(NextHopKey& nh)
     if (nh_id == SAI_NULL_OBJECT_ID)
     {
         throw std::runtime_error("NH Tunnel create failed for " + vnet_name_ + " ip " + nh.ip_address.to_string());
+    }
+
+    return nh_id;
+}
+
+sai_object_id_t VNetVrfObject::getExistingTunnelNextHopId(NextHopKey& nh)
+{
+    auto tun_name = getTunnelName();
+
+    VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
+
+    auto *tunnel_obj = vxlan_orch->getVxlanTunnel(tun_name);
+    sai_object_id_t nh_id = tunnel_obj->getNextHop(nh.ip_address, nh.mac_address, nh.vni);
+    if (nh_id == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_ERROR("NH Tunnel lookup failed for '%s' ip '%s'",
+                vnet_name_.c_str(), nh.ip_address.to_string().c_str());
     }
 
     return nh_id;
@@ -940,6 +958,73 @@ bool VNetRouteOrch::removeNextHopGroup(const string& vnet, const NextHopGroupKey
     return true;
 }
 
+bool VNetRouteOrch::removeNextHopGroupDirectly(const string& vnet, NextHopGroupInfo& nhg_info, const NextHopGroupKey &nexthops, VNetVrfObject *vrf_obj)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t next_hop_group_id = nhg_info.next_hop_group_id;
+    sai_status_t status;
+
+    SWSS_LOG_NOTICE("Direct delete next hop group %s", nexthops.to_string().c_str());
+
+    for (auto nhop = nhg_info.active_members.begin();
+         nhop != nhg_info.active_members.end();)
+    {
+        NextHopKey nexthop = nhop->first;
+
+        status = sai_next_hop_group_api->remove_next_hop_group_member(nhop->second);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to remove next hop group member %" PRIx64 ", rv:%d",
+                           nhop->second, status);
+            return false;
+        }
+
+        if (!isLocalEndpoint(vnet, nexthop.ip_address))
+        {
+            vrf_obj->removeTunnelNextHop(nexthop);
+        }
+
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
+        nhop = nhg_info.active_members.erase(nhop);
+    }
+
+    if (nexthops.getSize() > 1)
+    {
+        status = sai_next_hop_group_api->remove_next_hop_group(next_hop_group_id);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d", next_hop_group_id, status);
+            return false;
+        }
+
+        gRouteOrch->decreaseNextHopGroupCount();
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
+    }
+
+    return true;
+}
+
+bool VNetRouteOrch::removeFgNextHopGroup(const string& vnet, const NextHopGroupKey &nexthops, const IpPrefix& ipPrefix, VNetVrfObject *vrf_obj)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t vr_id = vrf_obj->getVRidIngress();
+    if (!gFgNhgOrch->removeFgNhgTunnel(vr_id, ipPrefix))
+    {
+        SWSS_LOG_ERROR("Failed to remove fine grained next hop group for %s, vr_id '0x%" PRIx64, ipPrefix.to_string().c_str(), vr_id);
+        return false;
+    }
+
+    for (auto nhop : nexthops.getNextHops())
+    {
+        vrf_obj->removeTunnelNextHop(nhop);
+    }
+
+    syncd_nexthop_groups_[vnet].erase(nexthops);
+    return true;
+}
+
 bool VNetRouteOrch::createNextHopGroup(const string& vnet,
                                        NextHopGroupKey& nexthops,
                                        VNetVrfObject *vrf_obj,
@@ -1135,6 +1220,78 @@ bool VNetRouteOrch::selectNextHopGroup(const string& vnet,
     return true;
 }
 
+bool VNetRouteOrch::selectFgNextHopGroup(const string& vnet,
+                                       NextHopGroupKey& nexthops,
+                                       IpPrefix& ipPrefix,
+                                       VNetVrfObject *vrf_obj,
+                                       const uint16_t consistent_hashing_buckets,
+                                       bool& isNextHopIdChanged)
+{
+    // This function returns the next hop group which is to be used to in the hardware
+    // for fine grained ECMP tunnel routes.
+
+    bool nhg_exists = hasNextHopGroup(vnet, nexthops);
+    std::map<NextHopKey, sai_object_id_t> nhopgroup_members_set;
+
+    for (auto nh : nexthops.getNextHops())
+    {
+        sai_object_id_t next_hop_id;
+        if (nhg_exists)
+        {
+            // NHG already exists, look up existing tunnel NH IDs without incrementing refcount
+            next_hop_id = vrf_obj->getExistingTunnelNextHopId(nh);
+        }
+        else
+        {
+            // New NHG, create tunnel NHs (sets refcount to 1)
+            next_hop_id = vrf_obj->getTunnelNextHop(nh);
+        }
+        nhopgroup_members_set[nh] = next_hop_id;
+    }
+
+    sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;
+
+    sai_object_id_t vrf_id;
+    vnet_orch_->getVrfIdByVnetName(vnet, vrf_id);
+    if (!gFgNhgOrch->setFgNhgTunnel(vrf_id, ipPrefix, nhopgroup_members_set, nexthops, consistent_hashing_buckets, nh_id, isNextHopIdChanged))
+    {
+        SWSS_LOG_ERROR("Failed to create fine grained next hop group for VNET %s", vnet.c_str());
+
+        if (!nhg_exists)
+        {
+            for (auto nh : nexthops.getNextHops())
+            {
+                vrf_obj->removeTunnelNextHop(nh);
+            }
+        }
+        return false;
+    }
+
+    if (!nhg_exists)
+    {
+        NextHopGroupInfo next_hop_group_entry;
+        next_hop_group_entry.next_hop_group_id = nh_id;
+
+        /*
+        * Initialize the next hop group structure with ref_count as 0. This
+        * count will increase once the route is successfully syncd.
+        */
+        next_hop_group_entry.ref_count = 0;
+        syncd_nexthop_groups_[vnet][nexthops] = next_hop_group_entry;
+
+        for (auto nh : nexthops.getNextHops())
+        {
+            syncd_nexthop_groups_[vnet][nexthops].active_members[nh] = SAI_NULL_OBJECT_ID;
+        }
+    }
+    if (isNextHopIdChanged)
+    {
+        syncd_nexthop_groups_[vnet][nexthops].next_hop_group_id = nh_id;
+    }
+
+    return true;
+}
+
 template<>
 bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipPrefix,
                                                NextHopGroupKey& nexthops, string& op, string& profile,
@@ -1143,7 +1300,8 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                                                const int32_t tx_monitor_timer,
                                                NextHopGroupKey& nexthops_secondary,
                                                const IpPrefix& adv_prefix,
-                                               const map<NextHopKey, IpAddress>& monitors)
+                                               const map<NextHopKey, IpAddress>& monitors,
+                                               const uint16_t consistent_hashing_buckets)
 {
     SWSS_LOG_ENTER();
 
@@ -1178,68 +1336,151 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
     sai_ip_prefix_t pfx;
     copy(pfx, ipPrefix);
 
+    bool is_fg_route = (consistent_hashing_buckets > 0);
+
     if (op == SET_COMMAND)
     {
-        sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;
-        NextHopGroupKey active_nhg("", true);
-        if (!selectNextHopGroup(vnet, nexthops, nexthops_secondary, monitoring, rx_monitor_timer, tx_monitor_timer, ipPrefix, vrf_obj, active_nhg, monitors))
+        auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
+
+        // Determine if the route was previously fine-grained
+        sai_object_id_t vr_id_check = vrf_obj->getVRidIngress();
+        bool was_fg = (it_route != syncd_tunnel_routes_[vnet].end())
+                      && gFgNhgOrch->syncdContainsFgNhg(vr_id_check, ipPrefix);
+
+        NextHopGroupKey old_nhg_key;
+        if (it_route != syncd_tunnel_routes_[vnet].end())
         {
-            return true;
+            old_nhg_key = it_route->second.nhg_key;
         }
 
-        // note: nh_id can be SAI_NULL_OBJECT_ID when active_nhg is empty.
-        nh_id = syncd_nexthop_groups_[vnet][active_nhg].next_hop_group_id;
+        bool is_type_transition = (it_route != syncd_tunnel_routes_[vnet].end())
+                                  && (was_fg != is_fg_route);
 
-        auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
+        // If transitioning from regular -? fg or vice versa with same endpoints, collision will occur on same NHG key.
+        // save old NHG info and evict from map before creating new one.
+        NextHopGroupInfo saved_old_nhg_info;
+        bool collision = is_type_transition && hasNextHopGroup(vnet, nexthops);
+        if (collision)
+        {
+            saved_old_nhg_info = syncd_nexthop_groups_[vnet][old_nhg_key];
+            syncd_nexthop_groups_[vnet].erase(old_nhg_key);
+        }
+
+        sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;
+        bool isNextHopIdChanged = false;
+        NextHopGroupKey active_nhg("", true);
+
+        std::map<NextHopKey, swss::IpAddress> origin_primary_monitors;
+        std::map<NextHopKey, swss::IpAddress> origin_secondary_monitors;
+
+        if (is_fg_route)
+        {
+            if (!selectFgNextHopGroup(vnet, nexthops, ipPrefix, vrf_obj,
+                                      consistent_hashing_buckets, isNextHopIdChanged))
+            {
+                if (collision)
+                {
+                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                }
+                return true;
+            }
+            active_nhg = nexthops;
+            nh_id = syncd_nexthop_groups_[vnet][nexthops].next_hop_group_id;
+        }
+        else
+        {
+
+            if (!selectNextHopGroup(vnet, nexthops, nexthops_secondary, monitoring,
+                                    rx_monitor_timer, tx_monitor_timer, ipPrefix,
+                                    vrf_obj, active_nhg, monitors))
+            {
+                if (collision)
+                {
+                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                }
+                return true;
+            }
+            nh_id = syncd_nexthop_groups_[vnet][active_nhg].next_hop_group_id;
+        }
+
+        sai_object_id_t old_nh_id = SAI_NULL_OBJECT_ID;
+        if (it_route != syncd_tunnel_routes_[vnet].end())
+        {
+            old_nh_id = collision ? saved_old_nhg_info.next_hop_group_id
+                                  : syncd_nexthop_groups_[vnet][old_nhg_key].next_hop_group_id;
+        }
+
         for (auto vr_id : vr_set)
         {
             bool route_status = true;
 
-            // Remove route if the nexthop group has no active endpoint
-            if (syncd_nexthop_groups_[vnet][active_nhg].active_members.empty())
+            if (is_fg_route)
             {
-                if (it_route != syncd_tunnel_routes_[vnet].end())
-                {
-                    NextHopGroupKey nhg = it_route->second.nhg_key;
-                    // Remove route when updating from a nhg with active member to another nhg without
-                    if (!syncd_nexthop_groups_[vnet][nhg].active_members.empty())
-                    {
-                        del_route(vr_id, pfx);
-                    }
-                }
-            }
-            else
-            {
-                auto prefixToRemove = ipPrefix;
-                if (adv_prefix.to_string() != ipPrefix.to_string())
-                {
-                    prefixToRemove = adv_prefix;
-                }
-                auto prefixSubnet = prefixToRemove.getSubnet();
-                if(gRouteOrch && gRouteOrch->isRouteExists(vr_id, prefixSubnet))
-                {
-                    if (!gRouteOrch->removeRoutePrefix(prefixSubnet))
-                    {
-                        SWSS_LOG_ERROR("Could not remove existing bgp route for prefix: %s\n", prefixSubnet.to_string().c_str());
-                        return false;
-                    }
-                    SWSS_LOG_INFO("Successfully removed existing bgp route for prefix: %s\n",
-                                  prefixSubnet.to_string().c_str());
-                }
                 if (it_route == syncd_tunnel_routes_[vnet].end())
                 {
                     route_status = add_route(vr_id, pfx, nh_id);
                 }
+                else if (nh_id != old_nh_id || isNextHopIdChanged)
+                {
+                    route_status = update_route(vr_id, pfx, nh_id);
+                }
+            }
+            else
+            {
+                if (syncd_nexthop_groups_[vnet][active_nhg].active_members.empty())
+                {
+                    if (it_route != syncd_tunnel_routes_[vnet].end())
+                    {
+                        NextHopGroupKey nhg = it_route->second.nhg_key;
+                        if (collision)
+                        {
+                            if (!saved_old_nhg_info.active_members.empty())
+                            {
+                                del_route(vr_id, pfx);
+                            }
+                        }
+                        else if (!syncd_nexthop_groups_[vnet][nhg].active_members.empty())
+                        {
+                            del_route(vr_id, pfx);
+                        }
+                    }
+                }
                 else
                 {
-                    NextHopGroupKey nhg = it_route->second.nhg_key;
-                    if (syncd_nexthop_groups_[vnet][nhg].active_members.empty())
+                    auto prefixToRemove = ipPrefix;
+                    if (adv_prefix.to_string() != ipPrefix.to_string())
+                    {
+                        prefixToRemove = adv_prefix;
+                    }
+                    auto prefixSubnet = prefixToRemove.getSubnet();
+                    if (gRouteOrch && gRouteOrch->isRouteExists(vr_id, prefixSubnet))
+                    {
+                        if (!gRouteOrch->removeRoutePrefix(prefixSubnet))
+                        {
+                            SWSS_LOG_ERROR("Could not remove existing bgp route for prefix: %s\n", prefixSubnet.to_string().c_str());
+                            if (collision)
+                            {
+                                syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                            }
+                            return false;
+                        }
+                        SWSS_LOG_INFO("Successfully removed existing bgp route for prefix: %s\n",
+                                      prefixSubnet.to_string().c_str());
+                    }
+                    if (it_route == syncd_tunnel_routes_[vnet].end())
                     {
                         route_status = add_route(vr_id, pfx, nh_id);
                     }
-                    else
+                    else if (nh_id != old_nh_id)
                     {
-                        route_status = update_route(vr_id, pfx, nh_id);
+                        if (collision || !syncd_nexthop_groups_[vnet][old_nhg_key].active_members.empty())
+                        {
+                            route_status = update_route(vr_id, pfx, nh_id);
+                        }
+                        else
+                        {
+                            route_status = add_route(vr_id, pfx, nh_id);
+                        }
                     }
                 }
             }
@@ -1247,75 +1488,177 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             if (!route_status)
             {
                 SWSS_LOG_ERROR("Route add/update failed for %s, vr_id '0x%" PRIx64, ipPrefix.to_string().c_str(), vr_id);
-                /* Clean up the newly created next hop group entry */
-                if (active_nhg.getSize() > 1)
+                if (is_fg_route)
+                {
+                    removeFgNextHopGroup(vnet, nexthops, ipPrefix, vrf_obj);
+                }
+                else if (active_nhg.getSize() > 1)
                 {
                     removeNextHopGroup(vnet, active_nhg, vrf_obj);
+                }
+                if (collision)
+                {
+                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
                 }
                 return false;
             }
         }
+
         bool route_updated = false;
         bool priority_route_updated = false;
-        if (it_route != syncd_tunnel_routes_[vnet].end() &&
-            ((monitoring == "" && it_route->second.nhg_key != nexthops) ||
-            ((monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD) && (it_route->second.primary != nexthops || it_route->second.secondary != nexthops_secondary))))
+        if (it_route != syncd_tunnel_routes_[vnet].end())
         {
-            route_updated = true;
-            NextHopGroupKey nhg = it_route->second.nhg_key;
-            if (monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD)
+            if (collision)
             {
-                // if the previously active NHG is same as the newly created active NHG.case of primary secondary swap or
-                //when primary is active and secondary is changed or vice versa. In these cases we dont remove the NHG
-                // but only remove the monitors for the set which has changed.
-                if (it_route->second.primary != nexthops)
+                route_updated = true;
+                if (--saved_old_nhg_info.ref_count == 0)
                 {
-                    delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
-                }
-                if (it_route->second.secondary != nexthops_secondary)
-                {
-                    delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
-                }
-                if (monitor_info_[vnet][ipPrefix].empty())
-                {
-                    monitor_info_[vnet].erase(ipPrefix);
-                }
-                priority_route_updated = true;
-            }
-            else
-            {
-                // In case of updating an existing route, decrease the reference count for the previous nexthop group
-                if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
-                {
-                    if (nhg.getSize() > 1)
+                    if (was_fg)
                     {
-                        removeNextHopGroup(vnet, nhg, vrf_obj);
+                        gFgNhgOrch->removeFgNhgTunnel(vrf_obj->getVRidIngress(), ipPrefix);
+                        for (auto nh : old_nhg_key.getNextHops())
+                        {
+                            vrf_obj->removeTunnelNextHop(nh);
+                        }
                     }
                     else
                     {
-                        syncd_nexthop_groups_[vnet].erase(nhg);
-                        if(nhg.getSize() == 1)
-                        {
-                            NextHopKey nexthop = *nhg.getNextHops().begin();
-                            if (!isLocalEndpoint(vnet, nexthop.ip_address))
-                            {
-                                vrf_obj->removeTunnelNextHop(nexthop);
-                            }
-                        }
+                        removeNextHopGroupDirectly(vnet, saved_old_nhg_info, old_nhg_key, vrf_obj);
                     }
-                    if (monitoring != VNET_MONITORING_TYPE_CUSTOM && monitoring != VNET_MONITORING_TYPE_CUSTOM_BFD)
+                    if (!was_fg)
                     {
-                        delEndpointMonitor(vnet, nhg, ipPrefix);
+                        delEndpointMonitor(vnet, old_nhg_key, ipPrefix);
                     }
                 }
                 else
                 {
-                    syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+                    saved_old_nhg_info.tunnel_routes.erase(ipPrefix);
+                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
                 }
                 vrf_obj->removeRoute(ipPrefix);
                 vrf_obj->removeProfile(ipPrefix);
             }
+            else if (is_type_transition && old_nhg_key != active_nhg)
+            {
+                // Type transition with different endpoints — no collision
+                route_updated = true;
+                if (--syncd_nexthop_groups_[vnet][old_nhg_key].ref_count == 0)
+                {
+                    if (was_fg)
+                    {
+                        removeFgNextHopGroup(vnet, old_nhg_key, ipPrefix, vrf_obj);
+                    }
+                    else
+                    {
+                        if (old_nhg_key.getSize() > 1)
+                        {
+                            removeNextHopGroup(vnet, old_nhg_key, vrf_obj);
+                        }
+                        else
+                        {
+                            syncd_nexthop_groups_[vnet].erase(old_nhg_key);
+                            if (old_nhg_key.getSize() == 1)
+                            {
+                                NextHopKey nexthop = *old_nhg_key.getNextHops().begin();
+                                if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                                {
+                                    vrf_obj->removeTunnelNextHop(nexthop);
+                                }
+                            }
+                        }
+                        delEndpointMonitor(vnet, old_nhg_key, ipPrefix);
+                    }
+                }
+                else
+                {
+                    syncd_nexthop_groups_[vnet][old_nhg_key].tunnel_routes.erase(ipPrefix);
+                }
+                vrf_obj->removeRoute(ipPrefix);
+                vrf_obj->removeProfile(ipPrefix);
+            }
+            else if (is_fg_route && !is_type_transition)
+            {
+                // FG → FG update with different endpoints
+                if (it_route->second.nhg_key != nexthops)
+                {
+                    route_updated = true;
+                    NextHopGroupKey nhg = it_route->second.nhg_key;
+                    if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+                    {
+                        for (auto nh : nhg.getNextHops())
+                        {
+                            vrf_obj->removeTunnelNextHop(nh);
+                        }
+                        syncd_nexthop_groups_[vnet].erase(nhg);
+                    }
+                    else
+                    {
+                        syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+                    }
+                    vrf_obj->removeRoute(ipPrefix);
+                }
+            }
+            else if (!is_fg_route && !is_type_transition)
+            {
+                if ((monitoring == "" && it_route->second.nhg_key != nexthops) ||
+                    ((monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD) &&
+                     (it_route->second.primary != nexthops || it_route->second.secondary != nexthops_secondary)))
+                {
+                    route_updated = true;
+                    NextHopGroupKey nhg = it_route->second.nhg_key;
+                    if (monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD)
+                    {
+                        if (it_route->second.primary != nexthops)
+                        {
+                            delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
+                        }
+                        if (it_route->second.secondary != nexthops_secondary)
+                        {
+                            delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
+                        }
+                        if (monitor_info_[vnet][ipPrefix].empty())
+                        {
+                            monitor_info_[vnet].erase(ipPrefix);
+                        }
+                        priority_route_updated = true;
+                    }
+                    else
+                    {
+                        if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+                        {
+                            if (nhg.getSize() > 1)
+                            {
+                                removeNextHopGroup(vnet, nhg, vrf_obj);
+                            }
+                            else
+                            {
+                                syncd_nexthop_groups_[vnet].erase(nhg);
+                                if (nhg.getSize() == 1)
+                                {
+                                    NextHopKey nexthop = *nhg.getNextHops().begin();
+                                    if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                                    {
+                                        vrf_obj->removeTunnelNextHop(nexthop);
+                                    }
+                                }
+                            }
+                            if (monitoring != VNET_MONITORING_TYPE_CUSTOM && monitoring != VNET_MONITORING_TYPE_CUSTOM_BFD)
+                            {
+                                delEndpointMonitor(vnet, nhg, ipPrefix);
+                            }
+                        }
+                        else
+                        {
+                            syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+                        }
+                        vrf_obj->removeRoute(ipPrefix);
+                        vrf_obj->removeProfile(ipPrefix);
+                    }
+                }
+            }
         }
+
+        // --- STEP 4: Update syncd_tunnel_routes_ ---
         if (!profile.empty())
         {
             vrf_obj->addProfile(ipPrefix, profile);
@@ -1323,14 +1666,15 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         if (it_route == syncd_tunnel_routes_[vnet].end() || route_updated)
         {
             syncd_nexthop_groups_[vnet][active_nhg].tunnel_routes.insert(ipPrefix);
+            syncd_nexthop_groups_[vnet][active_nhg].ref_count++;
+
             VNetTunnelRouteEntry tunnel_route_entry;
             tunnel_route_entry.nhg_key = active_nhg;
             tunnel_route_entry.primary = nexthops;
             tunnel_route_entry.secondary = nexthops_secondary;
             syncd_tunnel_routes_[vnet][ipPrefix] = tunnel_route_entry;
-            syncd_nexthop_groups_[vnet][active_nhg].ref_count++;
 
-            if (priority_route_updated)
+            if (!is_fg_route && (priority_route_updated))
             {
                 MonitorUpdate update;
                 update.prefix = ipPrefix;
@@ -1340,14 +1684,14 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 return true;
             }
 
-            if (adv_prefix.to_string() != ipPrefix.to_string() && prefix_to_adv_prefix_.find(ipPrefix) == prefix_to_adv_prefix_.end())
+            if (!is_fg_route && adv_prefix.to_string() != ipPrefix.to_string() && prefix_to_adv_prefix_.find(ipPrefix) == prefix_to_adv_prefix_.end())
             {
                 prefix_to_adv_prefix_[ipPrefix] = adv_prefix;
                 if (adv_prefix_refcount_.find(adv_prefix) == adv_prefix_refcount_.end())
                 {
                     adv_prefix_refcount_[adv_prefix] = 0;
                 }
-                if(active_nhg.getSize() > 0)
+                if (active_nhg.getSize() > 0)
                 {
                     adv_prefix_refcount_[adv_prefix] += 1;
                 }
@@ -1367,9 +1711,12 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         }
         NextHopGroupKey nhg = it_route->second.nhg_key;
         auto last_nhg_size = nhg.getSize();
+
+        // Determine if route is currently fine-grained
+        bool route_is_fg = gFgNhgOrch->syncdContainsFgNhg(vrf_obj->getVRidIngress(), ipPrefix);
+
         for (auto vr_id : vr_set)
         {
-            // If an nhg has no active member, the route should already be removed
             if (!syncd_nexthop_groups_[vnet][nhg].active_members.empty())
             {
                 if (!del_route(vr_id, pfx))
@@ -1378,40 +1725,45 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                     return false;
                 }
                 SWSS_LOG_INFO("Successfully deleted the route for prefix: %s", ipPrefix.to_string().c_str());
-
             }
         }
 
-        if(--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+        if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
         {
-            if (nhg.getSize() > 1)
+            if (route_is_fg)
             {
-                removeNextHopGroup(vnet, nhg, vrf_obj);
+                removeFgNextHopGroup(vnet, nhg, ipPrefix, vrf_obj);
             }
             else
             {
-                syncd_nexthop_groups_[vnet].erase(nhg);
-                // We need to check specifically if there is only one next hop active.
-                // In case of Priority routes we can end up in a situation where the active NHG has 0 nexthops.
-                if(nhg.getSize() == 1)
+                if (nhg.getSize() > 1)
                 {
-                    NextHopKey nexthop = *nhg.getNextHops().begin();
-                    if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                    removeNextHopGroup(vnet, nhg, vrf_obj);
+                }
+                else
+                {
+                    syncd_nexthop_groups_[vnet].erase(nhg);
+                    if (nhg.getSize() == 1)
                     {
-                        vrf_obj->removeTunnelNextHop(nexthop);
+                        NextHopKey nexthop = *nhg.getNextHops().begin();
+                        if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                        {
+                            vrf_obj->removeTunnelNextHop(nexthop);
+                        }
                     }
                 }
-            }
-            if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
-            {
-                delEndpointMonitor(vnet, nhg, ipPrefix);
+                if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
+                {
+                    delEndpointMonitor(vnet, nhg, ipPrefix);
+                }
             }
         }
         else
         {
             syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
         }
-        if (monitor_info_[vnet].find(ipPrefix) != monitor_info_[vnet].end())
+
+        if (!route_is_fg && monitor_info_[vnet].find(ipPrefix) != monitor_info_[vnet].end())
         {
             delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
             delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
@@ -1426,8 +1778,8 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
 
         vrf_obj->removeRoute(ipPrefix);
         vrf_obj->removeProfile(ipPrefix);
-
         removeRouteState(vnet, ipPrefix);
+
         if (prefix_to_adv_prefix_.find(ipPrefix) != prefix_to_adv_prefix_.end())
         {
             auto adv_pfx = prefix_to_adv_prefix_[ipPrefix];
@@ -3072,6 +3424,7 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
     string monitoring;
     int32_t rx_monitor_timer = -1;
     int32_t tx_monitor_timer = -1;
+    uint16_t consistent_hashing_buckets = 0;
     swss::IpPrefix adv_prefix;
     bool has_priority_ep = false;
     bool has_adv_pfx = false;
@@ -3124,6 +3477,10 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
         else if (name == "tx_monitor_timer")
         {
             tx_monitor_timer = static_cast<int32_t>(request.getAttrUint(name));
+        }
+        else if (name == "consistent_hashing_buckets")
+        {
+            consistent_hashing_buckets = static_cast<uint16_t>(request.getAttrUint(name));
         }
         else
         {
@@ -3260,7 +3617,11 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
     }
     if (vnet_orch_->isVnetExecVrf())
     {
-        return doRouteTask<VNetVrfObject>(vnet_name, ip_pfx, (has_priority_ep == true) ? nhg_primary : nhg, op, profile, monitoring, rx_monitor_timer, tx_monitor_timer, nhg_secondary, adv_prefix, monitors);
+        return doRouteTask<VNetVrfObject>(vnet_name, ip_pfx,
+            (has_priority_ep) ? nhg_primary : nhg, op, profile,
+            monitoring, rx_monitor_timer, tx_monitor_timer,
+            nhg_secondary, adv_prefix, monitors,
+            consistent_hashing_buckets);
     }
 
     return true;

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -219,6 +219,7 @@ public:
     bool hasRoute(IpPrefix& ipPrefix);
 
     sai_object_id_t getTunnelNextHop(NextHopKey& nh);
+    sai_object_id_t getExistingTunnelNextHopId(NextHopKey& nh);
     bool removeTunnelNextHop(NextHopKey& nh);
     void increaseNextHopRefCount(const nextHop&);
     void decreaseNextHopRefCount(const nextHop&);
@@ -316,7 +317,8 @@ const request_description_t vnet_route_description = {
         { "check_directly_connected", REQ_T_BOOL },
         { "rx_monitor_timer",       REQ_T_UINT },
         { "tx_monitor_timer",       REQ_T_UINT },
-        { "metric",                 REQ_T_UINT }
+        { "metric",                 REQ_T_UINT },
+        { "consistent_hashing_buckets", REQ_T_UINT },
     },
     { }
 };
@@ -523,6 +525,8 @@ private:
     bool addNextHopGroup(const string&, const NextHopGroupKey&, VNetVrfObject *vrf_obj,
                             const string& monitoring, const bool isLocalEp=false);
     bool removeNextHopGroup(const string&, const NextHopGroupKey&, VNetVrfObject *vrf_obj);
+    bool removeNextHopGroupDirectly(const string&, NextHopGroupInfo&, const NextHopGroupKey&, VNetVrfObject *vrf_obj);
+    bool removeFgNextHopGroup(const string&, const NextHopGroupKey&, const IpPrefix&, VNetVrfObject *vrf_obj);
     bool createNextHopGroup(const string&, NextHopGroupKey&, VNetVrfObject *vrf_obj,
                             const string& monitoring);
     NextHopGroupKey getActiveNHSet(const string&, NextHopGroupKey&, const IpPrefix& );
@@ -530,6 +534,7 @@ private:
     bool selectNextHopGroup(const string&, NextHopGroupKey&, NextHopGroupKey&, const string&, const int32_t, const int32_t, IpPrefix&,
                             VNetVrfObject *vrf_obj, NextHopGroupKey&,
                             const std::map<NextHopKey,IpAddress>& monitors=std::map<NextHopKey, IpAddress>());
+    bool selectFgNextHopGroup(const string&, NextHopGroupKey&, IpPrefix&, VNetVrfObject *vrf_obj, const uint16_t consistent_hashing_buckets, bool &isNextHopIdChanged);
 
     void createBfdSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr, const int32_t rx_monitor_timer, const int32_t tx_monitor_timer);
     void removeBfdSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr);
@@ -558,7 +563,8 @@ private:
     bool doRouteTask(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops, string& op, string& profile,
                     const string& monitoring, const int32_t rx_monitor_timer, const int32_t tx_monitor_timer,
                     NextHopGroupKey& nexthops_secondary, const IpPrefix& adv_prefix,
-                    const std::map<NextHopKey, IpAddress>& monitors=std::map<NextHopKey, IpAddress>());
+                    const std::map<NextHopKey, IpAddress>& monitors=std::map<NextHopKey, IpAddress>(),
+                    const uint16_t consistent_hashing_buckets = 0);
 
     template<typename T>
     bool doRouteTask(const string& vnet, IpPrefix& ipPrefix, nextHop& nh, string& op);

--- a/tests/test_fgnhg.py
+++ b/tests/test_fgnhg.py
@@ -32,21 +32,22 @@ def remove_entry(db, table, key):
     db.delete_entry(table, key)
     db.wait_for_deleted_entry(table,key)
 
-def get_asic_route_key(asic_db, ipprefix):
+def get_asic_route_key(asic_db, ipprefix, vr=None):
     route_exists = False
     key = ''
     keys = asic_db.get_keys(ASIC_ROUTE_TB)
     for k in keys:
         rt_key = json.loads(k)
-
         if rt_key['dest'] == ipprefix:
-            route_exists = True
-            key = k
-            break
+            if vr is None or rt_key.get('vr') == vr:
+                route_exists = True
+                key = k
+                break
+        
     assert route_exists
     return key
 
-def validate_asic_nhg_fine_grained_ecmp(asic_db, ipprefix, size):
+def validate_asic_nhg_fine_grained_ecmp(asic_db, ipprefix, size, vr=None):
     def _access_function():
         false_ret = (False, '')
         keys = asic_db.get_keys(ASIC_ROUTE_TB)
@@ -55,8 +56,10 @@ def validate_asic_nhg_fine_grained_ecmp(asic_db, ipprefix, size):
         for k in keys:
             rt_key = json.loads(k)
             if rt_key['dest'] == ipprefix:
-                route_exists = True
-                key = k
+                if vr is None or rt_key.get('vr') == vr:
+                    route_exists = True
+                    key = k
+                    break
         if not route_exists:
             return false_ret
 
@@ -137,6 +140,12 @@ def validate_asic_nhg_regular_ecmp(asic_db, ipprefix):
         return (True, nhgid)
     _, result = wait_for_result(_access_function, failure_message="SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP not found")
     return result
+
+def get_expected_key(vnet_name, fg_nhg_prefix):
+    if vnet_name == "":
+        return fg_nhg_prefix
+    else:
+        return vnet_name + "|" + fg_nhg_prefix
 
 def get_nh_oid_map(asic_db):
     nh_oid_map = {}
@@ -230,12 +239,13 @@ def run_warm_reboot(dvs):
     dvs.runcmd(['sh', '-c', 'supervisorctl start neighsyncd'])
     dvs.runcmd(['sh', '-c', 'supervisorctl start restore_neighbors'])
 
-def verify_programmed_fg_state_db_entry(state_db, fg_nhg_prefix, nh_memb_exp_count):
+def verify_programmed_fg_state_db_entry(state_db, fg_nhg_prefix, nh_memb_exp_count, vnet_name=""):
     memb_dict = nh_memb_exp_count
     keys = state_db.get_keys("FG_ROUTE_TABLE")
     assert len(keys) !=  0
+    expected_key = get_expected_key(vnet_name, fg_nhg_prefix)
     for key in keys:
-        if key != fg_nhg_prefix:
+        if key != expected_key:
             continue
         fvs = state_db.get_entry("FG_ROUTE_TABLE", key)
         assert fvs != {}
@@ -246,15 +256,16 @@ def verify_programmed_fg_state_db_entry(state_db, fg_nhg_prefix, nh_memb_exp_cou
     for idx,memb in memb_dict.items():
         assert memb == 0
 
-def verify_fg_state_db_for_even_distribution(state_db, fg_nhg_prefix, bucket_size, nh_ip_count):
+def verify_fg_state_db_for_even_distribution(state_db, fg_nhg_prefix, bucket_size, nh_ip_count, vnet_name=""):
     def _access_function():
         false_ret = (False, '')
         ret = True
         keys = state_db.get_keys("FG_ROUTE_TABLE")
         if not keys:
             return false_ret
+        expected_key = get_expected_key(vnet_name, fg_nhg_prefix)
         for key in keys:
-            if key != fg_nhg_prefix:
+            if key != expected_key:
                 continue
             fvs = state_db.get_entry("FG_ROUTE_TABLE", key)
             if not fvs:
@@ -282,17 +293,17 @@ def verify_fg_state_db_for_even_distribution(state_db, fg_nhg_prefix, bucket_siz
     assert status, f"Member count distribution is uneven"
 
 def validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map, prev_memb_dict, num_exp_changes,
-                                fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size):
+                                fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name=""):
     state_db_entry_memb_exp_count = {}
 
     for ip, cnt in nh_memb_exp_count.items():
         state_db_entry_memb_exp_count[ip + '@' + ip_to_if_map[ip]] = cnt
     next_memb_dict = verify_programmed_fg_asic_db_entry(asic_db,prev_memb_dict,num_exp_changes,nh_memb_exp_count,nh_oid_map,nhgid,bucket_size)
-    verify_programmed_fg_state_db_entry(state_db, fg_nhg_prefix, state_db_entry_memb_exp_count)
+    verify_programmed_fg_state_db_entry(state_db, fg_nhg_prefix, state_db_entry_memb_exp_count, vnet_name)
     return next_memb_dict
 
 def program_route_and_validate_fine_grained_ecmp(app_db, asic_db, state_db, ip_to_if_map, prev_memb_dict, num_exp_changes,
-                            fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size):
+                            fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name=""):
     ips = ""
     ifs = ""
     for ip in nh_memb_exp_count:
@@ -307,10 +318,10 @@ def program_route_and_validate_fine_grained_ecmp(app_db, asic_db, state_db, ip_t
     fvs = swsscommon.FieldValuePairs([("nexthop", ips), ("ifname", ifs)])
     ps.set(fg_nhg_prefix, fvs)
     new_memb_dict = validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
-                        prev_memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size)
+                        prev_memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
     return new_memb_dict
 
-def program_route_and_validate_distribtution(app_db, state_db, ip_to_if_map, fg_nhg_prefix, nh_ips, bucket_size):
+def program_route_and_validate_distribtution(app_db, state_db, ip_to_if_map, fg_nhg_prefix, nh_ips, bucket_size, vnet_name=""):
     ips = ""
     ifs = ""
     for ip in nh_ips:
@@ -324,7 +335,7 @@ def program_route_and_validate_distribtution(app_db, state_db, ip_to_if_map, fg_
     ps = swsscommon.ProducerStateTable(app_db, ROUTE_TB)
     fvs = swsscommon.FieldValuePairs([("nexthop", ips), ("ifname", ifs)])
     ps.set(fg_nhg_prefix, fvs)
-    verify_fg_state_db_for_even_distribution(state_db, fg_nhg_prefix, bucket_size, len(nh_ips))
+    verify_fg_state_db_for_even_distribution(state_db, fg_nhg_prefix, bucket_size, len(nh_ips), vnet_name)
 
 def create_interface_n_fg_ecmp_config(dvs, nh_range_start, nh_range_end, fg_nhg_name):
     ip_to_if_map = {}
@@ -1605,7 +1616,6 @@ class TestFineGrainedNextHopGroup(object):
 
         # cleanup all entries
         remove_interface_n_fg_ecmp_config(dvs, 0, NUM_NHs+NUM_NHs_non_fgnhg, fg_nhg_name)
-
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -9,6 +9,7 @@ from swsscommon import swsscommon
 from pprint import pprint
 from dvslib.dvs_common import wait_for_result
 from vnet_lib import *
+import test_fgnhg
 
 class TestVnetOrch(object):
 
@@ -3847,6 +3848,169 @@ class TestVnetOrch(object):
                 "Link-local trap route %s not cleaned up after VNET delete" % k
             )
 
+    '''
+    Test for vnet tunnel routes with fine-grained ECMP using consistent_hashing_buckets
+    '''
+    def test_vnet_orch_36(self, dvs, testlog):
+        self.setup_db(dvs)
+        vnet_obj = self.get_vnet_obj()
+        asic_db = dvs.get_asic_db()
+        state_db = dvs.get_state_db()
+
+        tunnel_name = 'tunnel_36'
+        vnet_name = 'Vnet36'
+        fg_nhg_prefix = "100.100.36.0/24"
+        bucket_size = 60
+
+        vnet_obj.fetch_exist_entries(dvs)
+        initial_nhop_count = len(asic_db.get_keys(vnet_obj.ASIC_NEXT_HOP))
+
+        create_vxlan_tunnel(dvs, tunnel_name, '10.10.10.10')
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10036', "")
+
+        vnet_obj.check_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, '10036')
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '10.10.10.10')
+        
+        vnet_obj.fetch_exist_entries(dvs)
+        
+        vr_id = vnet_obj.vr_map[vnet_name]['ing']
+
+        # Create VNET route with consistent_hashing_buckets and 3 tunnel next hops for fine-grained ECMP
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name, '36.0.0.1,36.0.0.2,36.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=bucket_size)
+
+        asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG_MEMB, bucket_size)
+        nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, fg_nhg_prefix, bucket_size, vr_id)
+        
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        
+        ip_to_if_map = {
+            '36.0.0.1': '',
+            '36.0.0.2': '',
+            '36.0.0.3': '',
+            '36.0.0.4': '',
+            '36.0.0.5': '',
+            '36.0.0.6': '',
+            '36.0.0.7': '',
+            '36.0.0.8': ''
+        }
+        
+        check_state_db_routes(dvs, vnet_name, fg_nhg_prefix, ['36.0.0.1', '36.0.0.2', '36.0.0.3'])
+
+        num_exp_changes = 60
+        nh_memb_exp_count = {'36.0.0.1': 20, '36.0.0.2': 20, '36.0.0.3': 20}
+        prev_memb_dict = {}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            prev_memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Add 3 more nexthops
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name, '36.0.0.1,36.0.0.2,36.0.0.3,36.0.0.4,36.0.0.5,36.0.0.6',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C,00:12:34:56:78:9D,00:12:34:56:78:9E,00:12:34:56:78:9F', 
+                          consistent_hashing_buckets=bucket_size)
+        
+        time.sleep(2)
+
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        
+        check_state_db_routes(dvs, vnet_name, fg_nhg_prefix, ['36.0.0.1', '36.0.0.2', '36.0.0.3','36.0.0.4','36.0.0.5','36.0.0.6'])
+        
+        num_exp_changes = 30
+        nh_memb_exp_count = {'36.0.0.1': 10, '36.0.0.2': 10, '36.0.0.3': 10, '36.0.0.4': 10, '36.0.0.5': 10, '36.0.0.6': 10}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+        
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Update route with different endpoints
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name, '36.0.0.1,36.0.0.2,36.0.0.3,36.0.0.4,36.0.0.7,36.0.0.8',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C,00:12:34:56:78:9D,00:12:34:56:78:8E,00:12:34:56:78:8F', 
+                          consistent_hashing_buckets=bucket_size)
+        
+        time.sleep(2)
+
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        
+        check_state_db_routes(dvs, vnet_name, fg_nhg_prefix, ['36.0.0.1', '36.0.0.2', '36.0.0.3','36.0.0.4','36.0.0.7','36.0.0.8'])
+        
+        num_exp_changes = 20
+        nh_memb_exp_count = {'36.0.0.1': 10, '36.0.0.2': 10, '36.0.0.3': 10, '36.0.0.4': 10, '36.0.0.7': 10, '36.0.0.8': 10}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Remove one endpoint
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name, '36.0.0.1,36.0.0.2,36.0.0.3,36.0.0.4,36.0.0.7',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C,00:12:34:56:78:9D,00:12:34:56:78:8E', 
+                          consistent_hashing_buckets=bucket_size)
+        
+        time.sleep(2)
+
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        
+        check_state_db_routes(dvs, vnet_name, fg_nhg_prefix, ['36.0.0.1', '36.0.0.2', '36.0.0.3','36.0.0.4','36.0.0.7'])
+        
+        num_exp_changes = 10
+        nh_memb_exp_count = {'36.0.0.1': 12, '36.0.0.2': 12, '36.0.0.3': 12, '36.0.0.4': 12, '36.0.0.7': 12}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            memb_dict, 10, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+        
+        # create route for new vnet with same IP space
+        vnet_name_2 = 'Vnet37'
+        create_vnet_entry(dvs, vnet_name_2, tunnel_name, '10037', "")
+        
+        vnet_obj.check_vnet_entry(dvs, vnet_name_2)
+        
+        # Get VR ID for vnet_name_2
+        vr_id_2 = vnet_obj.vr_map[vnet_name_2]['ing']
+        
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name_2, '36.0.0.1,36.0.0.2,36.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=bucket_size)
+        
+        asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG_MEMB, 120)
+        nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, fg_nhg_prefix, bucket_size, vr_id_2)
+        
+        check_state_db_routes(dvs, vnet_name_2, fg_nhg_prefix, ['36.0.0.1', '36.0.0.2', '36.0.0.3'])
+
+        num_exp_changes = 60
+        nh_memb_exp_count = {'36.0.0.1': 20, '36.0.0.2': 20, '36.0.0.3': 20}
+        prev_memb_dict = {}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            prev_memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name_2)
+
+        # Clean up
+        vnet_obj.fetch_exist_entries(dvs)
+        asic_rt_key_1 = test_fgnhg.get_asic_route_key(asic_db, fg_nhg_prefix, vr_id)
+        asic_rt_key_2 = test_fgnhg.get_asic_route_key(asic_db, fg_nhg_prefix, vr_id_2)
+        
+        delete_vnet_routes(dvs, fg_nhg_prefix, vnet_name)
+        delete_vnet_routes(dvs, fg_nhg_prefix, vnet_name_2)
+        
+        time.sleep(2)
+        
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, [fg_nhg_prefix])
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name_2, [fg_nhg_prefix])
+        check_remove_state_db_routes(dvs, vnet_name, fg_nhg_prefix)
+        check_remove_state_db_routes(dvs, vnet_name_2, fg_nhg_prefix)
+
+        asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG_MEMB, 0)
+        asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG, 0)
+        asic_db.wait_for_n_keys(vnet_obj.ASIC_NEXT_HOP, initial_nhop_count)
+        
+        asic_db.wait_for_deleted_entry(test_fgnhg.ASIC_ROUTE_TB, asic_rt_key_1)
+        asic_db.wait_for_deleted_entry(test_fgnhg.ASIC_ROUTE_TB, asic_rt_key_2)
+        state_db.wait_for_n_keys("FG_ROUTE_TABLE", 0)
+
+        delete_vnet_entry(dvs, vnet_name)
+        delete_vnet_entry(dvs, vnet_name_2)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name_2)
+        
+        delete_vxlan_tunnel(dvs, tunnel_name)
+        vnet_obj.check_del_vxlan_tunnel(dvs)
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/vnet_lib.py
+++ b/tests/vnet_lib.py
@@ -140,11 +140,11 @@ def delete_vnet_local_routes(dvs, prefix, vnet_name):
     time.sleep(2)
 
 
-def create_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor="", profile="", primary="", monitoring="", rx_monitor_timer=-1, tx_monitor_timer=-1, adv_prefix="", check_directly_connected=False, metric=-1):
-    set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac=mac, vni=vni, ep_monitor=ep_monitor, profile=profile, primary=primary, monitoring=monitoring, rx_monitor_timer=rx_monitor_timer, tx_monitor_timer=tx_monitor_timer, adv_prefix=adv_prefix, check_directly_connected=check_directly_connected, metric=metric)
+def create_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor="", profile="", primary="", monitoring="", rx_monitor_timer=-1, tx_monitor_timer=-1, adv_prefix="", check_directly_connected=False, metric=-1, consistent_hashing_buckets=0):
+    set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac=mac, vni=vni, ep_monitor=ep_monitor, profile=profile, primary=primary, monitoring=monitoring, rx_monitor_timer=rx_monitor_timer, tx_monitor_timer=tx_monitor_timer, adv_prefix=adv_prefix, check_directly_connected=check_directly_connected, metric=metric, consistent_hashing_buckets=consistent_hashing_buckets)
 
 
-def set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor="", profile="", primary="", monitoring="", rx_monitor_timer=-1, tx_monitor_timer=-1, adv_prefix="", check_directly_connected=False, metric=-1):
+def set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor="", profile="", primary="", monitoring="", rx_monitor_timer=-1, tx_monitor_timer=-1, adv_prefix="", check_directly_connected=False, metric=-1, consistent_hashing_buckets=0):
     conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
 
     attrs = [
@@ -183,6 +183,9 @@ def set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor=
 
     if metric >= 0:
         attrs.append(('metric', str(metric)))
+
+    if consistent_hashing_buckets > 0:
+        attrs.append(('consistent_hashing_buckets', str(consistent_hashing_buckets)))
 
     tbl = swsscommon.Table(conf_db, "VNET_ROUTE_TUNNEL")
     fvs = swsscommon.FieldValuePairs(attrs)


### PR DESCRIPTION
CP of PR: https://github.com/sonic-net/sonic-swss/pull/4158

**What I did**
This PR adds support for fine-grained ECMP (FG-ECMP) for VNET tunnel routes using a new consistent_hashing_buckets attribute, wiring VNET route programming into the existing FG-NHG orchestration and extending tests accordingly.
Changed FG_ROUTE_TABLE schema to include Vnet name in the key.

**Changes:**

Extend VNET route configuration to accept consistent_hashing_buckets and plumb it through to VNetRouteOrch::doRouteTask, which now invokes FgNhgOrch to create/update fine-grained ECMP next-hop groups for tunnel routes.
Enhance FgNhgOrch to support FG-ECMP for non-default VRFs (VNET VRFs), including per-VNET state-DB keys (vnet|prefix) and a new overload of setFgNhg that can work directly with tunnel next-hop IDs and consistent hashing bucket sizes.
Add and update unit tests in test_vnet.py, vnet_lib.py, and test_fgnhg.py to exercise FG-ECMP behavior for VNET routes and to validate new state-DB key formats.

**Why I did it**
To allow consistent ecmp for VXLAN tunnels according to HLD https://github.com/sonic-net/SONiC/pull/2099

**How I verified it**
Via unit tests and datapath testing